### PR TITLE
feat: add support for i18n

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,14 @@
+{
+  "manifest_appDescription": {
+    "message": "Hypertrons，your best Github helper"
+  },
+  "manifest_appName": {
+    "message": "Hypertrons Robot"
+  },
+  "manifest_iconTitle": {
+    "message": "[loading……]"
+  },
+  "component_developerCollabrationNetwork_title": {
+    "message": "Developer Collabration Network"
+  }
+}

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -1,0 +1,14 @@
+{
+  "manifest_appDescription": {
+    "message": "Hypertrons，您的最佳Github助手"
+  },
+  "manifest_appName": {
+    "message": "Hypertrons机器人"
+  },
+  "manifest_iconTitle": {
+    "message": "[载入中……]"
+  },
+  "component_developerCollabrationNetwork_title": {
+    "message": "开发人员合作网络图"
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "Hypertrons",
+  "default_locale": "zh_CN",
   "icons": {
     "128": "128.png"
   },

--- a/src/pages/Content/components/DeveloperCollabrationNetwork/index.tsx
+++ b/src/pages/Content/components/DeveloperCollabrationNetwork/index.tsx
@@ -40,7 +40,7 @@ const DeveloperCollabrationNetwork: React.FC<DeveloperCollabrationNetworkProps> 
         });
         const options = {
           title: {
-            text: 'Developer Collabration Network',
+            text: chrome.i18n.getMessage("component_developerCollabrationNetwork_title"),
             textStyle: {
               fontSize: 14,
               fontWeight: 400,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,6 +136,19 @@ var options = {
         copyUnmodified: true,
       }
     ),
+    new CopyWebpackPlugin(
+      [
+        {
+          from: 'src/_locales',
+          to: path.join(__dirname, 'build','_locales'),
+          force: true,
+        },
+      ],
+      {
+        logLevel: 'info',
+        copyUnmodified: true,
+      }
+    ),
     new HtmlWebpackPlugin({
       template: path.join(__dirname, 'src', 'pages', 'Options', 'index.html'),
       filename: 'options.html',


### PR DESCRIPTION
This commit changes the way that we show information in our extension by using `chrome.i18n`.
From then on, we shouldn't hard-code these information.  
Just add an item in  both `/src/_locales/<zh_CN/en>/messages.json `:  
```json
{
      "manifest_appDescription": {
        "message": "Hypertrons，您的最佳Github助手"
      },
}
```
```json
{
      "manifest_appDescription": {
        "message": "Hypertrons，your best Github helper"
      },
}
```
And use `chrome.i18n.getMessage("manifest_appDescription")` to get the content of it.  

We can switch the default language in browser's settings and see how it will behavior.  

![image](https://user-images.githubusercontent.com/20047907/111767350-96907200-88e1-11eb-9ac2-018b7dbedb12.png)

![image](https://user-images.githubusercontent.com/20047907/111766381-6f857080-88e0-11eb-92c2-b3c9c4738359.png)

![image](https://user-images.githubusercontent.com/20047907/111767320-8c6e7380-88e1-11eb-934c-5e9f8c608b24.png)


