### PR TITLE
fix: modal too narrow when viewing networks

### DIFF
--- a/src/pages/Content/content.styles.css
+++ b/src/pages/Content/content.styles.css
@@ -34,4 +34,5 @@
 
 .ms-Dialog-main{
   max-width: 100%;
+  width: 50vw;
 }


### PR DESCRIPTION
## Purpose
Now the width of modal will be 50% of the window's .
![image](https://user-images.githubusercontent.com/20047907/118588146-6d506d00-b7d0-11eb-8a5b-de3197c178ea.png)

## Proposed changes
_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

#### Types of changes
_What types of changes does your code introduce to hypertrons-crx?_
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Approach
_How does this change address the problem?_


## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments (Optional)
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
_Links to blog posts, patterns, libraries or addons used to solve this problem_