### PR TITLE
fix: wrong update url bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypertrons-crx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Hypertrons Chrome Extension",
   "license": "Apache",

--- a/src/components/OptionsPage/index.tsx
+++ b/src/components/OptionsPage/index.tsx
@@ -36,6 +36,7 @@ const OptionsPage: React.FC = () => {
   const [notificationId, setNotificationId] = useState(0);
   const [notification, setNotification] = useState("");
   const [updateStatus, setUpdateStatus] = useState(UpdateStatus.undefine);
+  const [updateUrl, setUpdateUrl] = useState("https://github.com/hypertrons/hypertrons-crx/releases");
 
   const options: IChoiceGroupOption[] = [
     {
@@ -98,8 +99,9 @@ const OptionsPage: React.FC = () => {
   const checkUpdateManually = async () => {
     setUpdateStatus(UpdateStatus.undefine);
     setCheckingUpdate(true);
-    const [currentVersion, latestVersion] = await checkUpdate();
+    const [currentVersion, latestVersion,updateUrl] = await checkUpdate();
     if (compareVersion(currentVersion, latestVersion) === -1) {
+      setUpdateUrl(updateUrl);
       setUpdateStatus(UpdateStatus.yes);
     }
     else {
@@ -335,7 +337,7 @@ const OptionsPage: React.FC = () => {
                 isMultiline={false}
               >
                 {getMessageI18n("options_update_btn_updateStatusYes")}
-                <Link href="https://github.com/hypertrons/hypertrons-crx/" target="_blank" underline>
+                <Link href={updateUrl} target="_blank" underline>
                   {getMessageI18n("options_update_btn_getUpdate")}
                 </Link>
               </MessageBar>

--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -33,7 +33,6 @@ export const checkUpdate= async ()=>{
     latestVersion=updateInformation["develop"]["latest_version"];
     updateUrl=updateInformation["develop"]["url"];
   }
-  console.log(currentVersion,latestVersion,updateUrl);
   return [currentVersion,latestVersion,updateUrl];
 }
 

--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -15,6 +15,14 @@ export const checkUpdate= async ()=>{
     if(browserType==="Edge"){
       latestVersion=updateInformation["edge"]["latest_version"];
       updateUrl=updateInformation["edge"]["url"];
+      // edge can also install crx from chrome store
+      if("update_url" in details){
+        const update_url=details["update_url"]
+        if(update_url.search("google")!==-1){
+          latestVersion=updateInformation["chrome"]["latest_version"];
+          updateUrl=updateInformation["chrome"]["url"];
+        }
+      }
     }
     else{
       latestVersion=updateInformation["chrome"]["latest_version"];
@@ -25,6 +33,7 @@ export const checkUpdate= async ()=>{
     latestVersion=updateInformation["develop"]["latest_version"];
     updateUrl=updateInformation["develop"]["url"];
   }
+  console.log(currentVersion,latestVersion,updateUrl);
   return [currentVersion,latestVersion,updateUrl];
 }
 


### PR DESCRIPTION
## Purpose
Now when clicking `get update` in `options page`, user will be navigated to the right url in `update_information.json`.

## Proposed changes
_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

#### Types of changes
_What types of changes does your code introduce to hypertrons-crx?_
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Approach
_How does this change address the problem?_


## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments (Optional)
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
_Links to blog posts, patterns, libraries or addons used to solve this problem_