### PR TITLE
feat: add loading to perceptor layout

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -5,8 +5,8 @@
   "manifest_appName": {
     "message": "Hypertrons-crx Robot"
   },
-  "manifest_iconTitle": {
-    "message": "[Loading……]"
+  "golbal_loading": {
+    "message": "Loading……"
   },
   "global_error_message": {
     "message": "Sorry，an error occurred while loading Hypertrons-crx extention. Error Code is: "

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -5,8 +5,8 @@
   "manifest_appName": {
     "message": "Hypertrons-crx 机器人"
   },
-  "manifest_iconTitle": {
-    "message": "[载入中……]"
+  "golbal_loading": {
+    "message": "载入中......"
   },
   "global_error_message": {
     "message": "抱歉，Hypertrons-crx 插件加载时遇到了一点问题。错误代码为："

--- a/src/components/ExceptionPage/ErrorMessageBar.tsx
+++ b/src/components/ExceptionPage/ErrorMessageBar.tsx
@@ -35,9 +35,9 @@ const ErrorMessageBar: React.FC<ErrorMessageBarProps> = ({
           isMultiline={false}
           dismissButtonAriaLabel="Close"
         >
-          {getMessageByLocale("global_error_message",settings.locale)}{errorCode}.
+          {getMessageByLocale("global_error_message", settings.locale)}{errorCode}.
           <Link href={url} target="_blank" underline>
-            {getMessageByLocale("global_clickToshow",settings.locale)} Issue.
+            {getMessageByLocale("global_clickToshow", settings.locale)} Issue.
           </Link>
         </MessageBar>
       </Stack.Item>

--- a/src/components/ExceptionPage/ErrorPage.tsx
+++ b/src/components/ExceptionPage/ErrorPage.tsx
@@ -33,11 +33,11 @@ const ErrorPage: React.FC = () => {
         <FontIcon iconName="Error" />
       </Stack.Item>
       <Stack.Item align="center">
-        <Text>{getMessageByLocale("component_error_message",settings.locale)}</Text>
+        <Text>{getMessageByLocale("component_error_message", settings.locale)}</Text>
       </Stack.Item>
       <Stack.Item align="center">
         <DefaultButton
-          text={getMessageByLocale("global_btn_goBack",settings.locale)}
+          text={getMessageByLocale("global_btn_goBack", settings.locale)}
           iconProps={navigateBackIcon}
           onClick={onButtonClick}
         />

--- a/src/components/Graph/Graphin/index.tsx
+++ b/src/components/Graph/Graphin/index.tsx
@@ -55,7 +55,7 @@ const TooltipForNode = () => {
       <div style={{ margin: '5px' }}>
         <Persona
           text={model.id}
-          secondaryText={`${getMessageByLocale("global_activity",settings.locale)}: ${model.value.toString()}`}
+          secondaryText={`${getMessageByLocale("global_activity", settings.locale)}: ${model.value.toString()}`}
           size={PersonaSize.size24}
           showSecondaryText={true}
         />

--- a/src/components/OptionsPage/index.tsx
+++ b/src/components/OptionsPage/index.tsx
@@ -151,7 +151,7 @@ const OptionsPage: React.FC = () => {
           }}
           dialogContentProps={{
             type: DialogType.normal,
-            title: getMessageByLocale("global_notificationTitle",settings.locale)
+            title: getMessageByLocale("global_notificationTitle", settings.locale)
           }}
         >
           <Text variant="mediumPlus">

--- a/src/components/PopupPage/index.tsx
+++ b/src/components/PopupPage/index.tsx
@@ -88,7 +88,7 @@ const PopupPage: React.FC = () => {
                 width:120
               }}
             >
-              {getMessageByLocale("options_token_title",settings.locale)}
+              {getMessageByLocale("options_token_title", settings.locale)}
             </DefaultButton>
           }
         </Stack>

--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -39,8 +39,8 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
             {
               type: 'basic',
               iconUrl: 'main.png',
-              title: getMessageByLocale('notification_title_newUpdate',settings.locale),
-              message: getMessageByLocale('notification_message_newUpdate',settings.locale).replace('%v', latestVersion),
+              title: getMessageByLocale('notification_title_newUpdate', settings.locale),
+              message: getMessageByLocale('notification_message_newUpdate', settings.locale).replace('%v', latestVersion),
             }
           )
         }

--- a/src/pages/Content/PerceptorLayout.tsx
+++ b/src/pages/Content/PerceptorLayout.tsx
@@ -1,14 +1,29 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { render } from 'react-dom';
 import $ from 'jquery';
-import { Stack } from 'office-ui-fabric-react';
-import { isPerceptor, runsWhen } from '../../utils/utils';
+import { Spinner } from 'office-ui-fabric-react';
+import { getMessageByLocale, isPerceptor, runsWhen } from '../../utils/utils';
 import PerceptorBase from './PerceptorBase';
 import { inject2Perceptor } from './Perceptor';
+import Settings, { loadSettings } from '../../utils/settings';
 
 const PerceptorLayoutView: React.FC<{}> = () => {
+  const [settings,setSettings]= useState(new Settings());
+  const [inited, setInited] = useState(false);
+
+  useEffect(() => {
+    const initSettings=async ()=> {
+      const temp=await loadSettings();
+      setSettings(temp);
+      setInited(true);
+    }
+    if(!inited){
+      initSettings();
+    }
+  },[inited,settings]);
+
   return (
-    <Stack horizontalAlign="center" />
+    <Spinner label={getMessageByLocale("golbal_loading", settings.locale)} />
   )
 }
 @runsWhen([isPerceptor])

--- a/src/pages/Content/TeachingBubbleWrapper.tsx
+++ b/src/pages/Content/TeachingBubbleWrapper.tsx
@@ -41,7 +41,7 @@ const TeachingBubbleWrapper: React.FC<TeachingBubbleProps> =
 
     const disableButtonProps: IButtonProps = React.useMemo(
       () => ({
-        children: getMessageByLocale('global_btn_disable',settings.locale),
+        children: getMessageByLocale('global_btn_disable', settings.locale),
         onClick: async ()=>{
           metaData.showTeachingBubble=false;
           await chromeSet("meta_data", metaData.toJson());
@@ -53,7 +53,7 @@ const TeachingBubbleWrapper: React.FC<TeachingBubbleProps> =
 
     const confirmButtonProps: IButtonProps = React.useMemo(
       () => ({
-        children: getMessageByLocale("global_btn_ok",settings.locale),
+        children: getMessageByLocale("global_btn_ok", settings.locale),
         onClick: toggleTeachingBubbleVisible,
       }),
       [settings.locale, toggleTeachingBubbleVisible],
@@ -68,9 +68,9 @@ const TeachingBubbleWrapper: React.FC<TeachingBubbleProps> =
             primaryButtonProps={disableButtonProps}
             secondaryButtonProps={confirmButtonProps}
             onDismiss={toggleTeachingBubbleVisible}
-            headline={getMessageByLocale('teachingBubble_text_headline',settings.locale)}
+            headline={getMessageByLocale('teachingBubble_text_headline', settings.locale)}
           >
-            {getMessageByLocale('teachingBubble_text_content',settings.locale)}
+            {getMessageByLocale('teachingBubble_text_content', settings.locale)}
           </TeachingBubble>
         }
       </div>


### PR DESCRIPTION
## Purpose
User will be noticed to wait when it would take some time to get data from cdn in `PerceptorLayout` page.  


![20210605222900](https://user-images.githubusercontent.com/20047907/120895015-b9fbcb00-c64d-11eb-886e-04bc67affca1.png)

## Proposed changes
_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

#### Types of changes
_What types of changes does your code introduce to hypertrons-crx?_
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Approach
_How does this change address the problem?_


## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments (Optional)
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
_Links to blog posts, patterns, libraries or addons used to solve this problem_