### PR TITLE
fix: inconsistent names cause CI error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hypertrons-crx",
+  "name": "hypercrx",
   "version": "1.1.0",
   "private": true,
   "description": "Hypertrons Chromium Extension",
@@ -13,6 +13,7 @@
     "prettier": "prettier --write '**/*.{js,jsx,css,html}'"
   },
   "dependencies": {
+    "@antv/g6": "^4.5.0",
     "@antv/graphin": "^2.0.6",
     "@antv/graphin-components": "^2.0.7",
     "@fluentui/react": "^7.121.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -161,7 +161,7 @@ var options = {
       keyFile: 'build.pem',
       contentPath: 'build',
       outputPath: 'release',
-      name: 'hypertrons-crx'
+      name: 'hypercrx'
     })
   ],
 };


### PR DESCRIPTION
## CI problem
![image](https://user-images.githubusercontent.com/32434520/149859420-987a4e36-6fa5-4640-8c71-f3ccd24f32bb.png)

## Cause for the problem
![image](https://user-images.githubusercontent.com/32434520/149859971-fd87b8ae-eafa-4a92-a387-7e3443d4f1b6.png)

## Solution
Inconsistent names --> consistent names
![image](https://user-images.githubusercontent.com/32434520/149859672-ebe6394b-125f-4d13-bacd-261493ec14d8.png)

## Others
The NPM package name was already renamed at #198, but reverted by mistake (as I think) at #210, So I changed it to "hypercrx" again.

#### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)