### PR TITLE
fix: build errors introduced by last 2 PRs & inconsistent names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hypertrons-crx",
+  "name": "hypercrx",
   "version": "1.1.0",
   "private": true,
   "description": "Hypertrons Chromium Extension",
@@ -13,6 +13,7 @@
     "prettier": "prettier --write '**/*.{js,jsx,css,html}'"
   },
   "dependencies": {
+    "@antv/g6": "^4.5.3",
     "@antv/graphin": "^2.0.6",
     "@antv/graphin-components": "^2.0.7",
     "@fluentui/react": "^7.121.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercrx",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Hypertrons Chromium Extension",
   "license": "Apache",

--- a/publish/update_information.json
+++ b/publish/update_information.json
@@ -1,6 +1,6 @@
 {
   "chrome": {
-    "latest_version":"1.0.1",
+    "latest_version":"1.3.0",
     "url":"https://chrome.google.com/webstore/detail/hypertrons-crx/jkgfcnkgfapbckbpgobmgiphpknkiljm"
   },
   "edge": {
@@ -8,7 +8,7 @@
     "url":"https://microsoftedge.microsoft.com/addons/detail/hypertronscrx/lfdjlbagcbpjpdhlllcgglplcccnigip"
   },
   "develop": {
-    "latest_version":"1.0.1",
+    "latest_version":"1.3.0",
     "url":"https://github.com/hypertrons/hypertrons-crx/releases"
   }
 }

--- a/src/pages/Content/ContributorsActivityEvolution.tsx
+++ b/src/pages/Content/ContributorsActivityEvolution.tsx
@@ -106,7 +106,7 @@ const ContributorsActivityEvolution: React.FC<ContributorsActivityEvolutionProps
             <div style={{ margin: '10px 0 20px 20px' }}>
               <Stack className="hypertrons-crx-border">
                 <Stack.Item align="center">
-            <DynamicBar theme={githubTheme} width={700} height={600} barNumber={20} digitNumber={2} duration={20} dateLabelSize={30} dataUrl={`${API_TARGET}/dynamicbar_activities_v2/latest/${currentRepo}.csv`}/>
+            <DynamicBar theme={githubTheme as 'light' | 'dark'} width={700} height={600} barNumber={20} digitNumber={2} duration={20} dateLabelSize={30} dataUrl={`${API_TARGET}/dynamicbar_activities_v2/latest/${currentRepo}.csv`}/>
                 </Stack.Item>
               </Stack>
             </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,7 @@ var options = {
       },
       {
         test: /\.css$/,
-        use: ['style-loader','css-loader'],
+        use: ['style-loader', 'css-loader'],
         sideEffects: true,
       },
     ],
@@ -85,7 +85,7 @@ var options = {
     alias: alias,
     extensions: fileExtensions
       .map((extension) => '.' + extension)
-      .concat(['.jsx', '.js', '.ts','.tsx', '.css']),
+      .concat(['.jsx', '.js', '.ts', '.tsx', '.css']),
   },
   plugins: [
     new webpack.ProgressPlugin(),
@@ -109,7 +109,7 @@ var options = {
                 description: process.env.npm_package_description,
                 version: process.env.npm_package_version,
                 ...JSON.parse(content.toString()),
-                content_security_policy:content_security_policy
+                content_security_policy: content_security_policy,
               })
             );
           },
@@ -161,9 +161,12 @@ var options = {
       keyFile: 'build.pem',
       contentPath: 'build',
       outputPath: 'release',
-      name: 'hypertrons-crx'
-    })
+      name: 'hypercrx',
+    }),
   ],
+  node: {
+    fs: 'empty',
+  },
 };
 
 if (ENV.NODE_ENV === 'development') {


### PR DESCRIPTION
## CI problem
![image](https://user-images.githubusercontent.com/32434520/149859420-987a4e36-6fa5-4640-8c71-f3ccd24f32bb.png)

## Cause for the problem
1. Dependencies changes

2. tslint error & webpack options

3. Inconsistent names
![image](https://user-images.githubusercontent.com/32434520/149859971-fd87b8ae-eafa-4a92-a387-7e3443d4f1b6.png)

## Others
The NPM package name was already renamed at #198, but reverted by mistake (as I think) at #210, So I changed it to "hypercrx" again.

#### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)