### PR TITLE
[fix] relocate Perceptor Tab for new GitHub page layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercrx",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "description": "Hypertrons Chromium Extension",
   "license": "Apache",

--- a/publish/update_information.json
+++ b/publish/update_information.json
@@ -8,7 +8,7 @@
     "url": "https://microsoftedge.microsoft.com/addons/detail/hypertronscrx/lfdjlbagcbpjpdhlllcgglplcccnigip"
   },
   "develop": {
-    "latest_version": "1.4.7",
+    "latest_version": "1.4.8",
     "url": "https://github.com/hypertrons/hypertrons-crx/releases"
   }
 }

--- a/src/pages/ContentScripts/PerceptorLayout.tsx
+++ b/src/pages/ContentScripts/PerceptorLayout.tsx
@@ -12,15 +12,17 @@ const PerceptorLayoutView: React.FC = () => {
 class PerceptorLayout extends PerceptorBase {
   public async run(): Promise<void> {
     // remove the original container
-    const parentContainer = $('.container-xl.clearfix.new-discussion-timeline');
-    $('#repo-content-pjax-container', parentContainer).remove();
+    const parentContainer = $('#repo-content-pjax-container').children(
+      'div.clearfix.container-xl'
+    );
+    parentContainer.children('div.Layout').remove();
 
     // create the new one : percepter container
     const percepterContainer = document.createElement('div');
     percepterContainer.setAttribute('id', 'perceptor-layout');
 
     render(<PerceptorLayoutView />, percepterContainer);
-    parentContainer.prepend(percepterContainer);
+    parentContainer.append(percepterContainer);
   }
 }
 


### PR DESCRIPTION
Thanks for @LiuChangFreeman @heming6666 , The Perceptor page comes back!

fix #305.