### PR TITLE
[fix] Only injected public repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercrx",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "Hypertrons Chromium Extension",
   "license": "Apache",

--- a/publish/update_information.json
+++ b/publish/update_information.json
@@ -1,14 +1,14 @@
 {
   "chrome": {
-    "latest_version": "1.5.0",
+    "latest_version": "1.5.1",
     "url": "https://chrome.google.com/webstore/detail/hypertrons-crx/jkgfcnkgfapbckbpgobmgiphpknkiljm"
   },
   "edge": {
-    "latest_version": "1.5.0",
+    "latest_version": "1.5.1",
     "url": "https://microsoftedge.microsoft.com/addons/detail/hypertronscrx/lfdjlbagcbpjpdhlllcgglplcccnigip"
   },
   "develop": {
-    "latest_version": "1.5.0",
+    "latest_version": "1.5.1",
     "url": "https://github.com/hypertrons/hypertrons-crx/releases"
   }
 }

--- a/src/mock/background.data.ts
+++ b/src/mock/background.data.ts
@@ -1,14 +1,14 @@
 export const updateInformation = {
   chrome: {
-    latest_version: '1.5.0',
+    latest_version: '1.5.1',
     url: 'https://github.com/hypertrons/hypertrons-crx/releases',
   },
   edge: {
-    latest_version: '1.5.0',
+    latest_version: '1.5.1',
     url: 'https://github.com/hypertrons/hypertrons-crx/releases',
   },
   develop: {
-    latest_version: '1.5.0',
+    latest_version: '1.5.1',
     url: 'https://github.com/hypertrons/hypertrons-crx/releases',
   },
 };

--- a/src/pages/ContentScripts/Perceptor.tsx
+++ b/src/pages/ContentScripts/Perceptor.tsx
@@ -60,7 +60,7 @@ export class Perceptor extends PerceptorBase {
         logger.info(featureId, 'is disabled');
         return;
       }
-      if (!Feature.prototype.include.every((c: () => any) => c())) {
+      if (Feature.prototype.include.every((c: () => any) => !c())) {
         logger.info(featureId, 'does NOT run on this page');
         return;
       }

--- a/src/pages/ContentScripts/Perceptor.tsx
+++ b/src/pages/ContentScripts/Perceptor.tsx
@@ -60,7 +60,7 @@ export class Perceptor extends PerceptorBase {
         logger.info(featureId, 'is disabled');
         return;
       }
-      if (Feature.prototype.include.every((c: () => any) => !c())) {
+      if (!Feature.prototype.include.every((c: () => any) => c())) {
         logger.info(featureId, 'does NOT run on this page');
         return;
       }

--- a/src/pages/ContentScripts/PerceptorTab.tsx
+++ b/src/pages/ContentScripts/PerceptorTab.tsx
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import * as pageDetect from 'github-url-detection';
 import { utils } from 'github-url-detection';
-import { isPerceptor, runsWhen } from '../../utils/utils';
+import { isPerceptor, runsWhen, isPublic } from '../../utils/utils';
 import PerceptorBase from './PerceptorBase';
 import { inject2Perceptor } from './Perceptor';
 import { render } from 'react-dom';
@@ -9,7 +9,7 @@ import React from 'react';
 import TeachingBubbleWrapper from './TeachingBubbleWrapper';
 import logger from '../../utils/logger';
 
-@runsWhen([pageDetect.isRepo])
+@runsWhen([pageDetect.isRepo, isPublic])
 class PerceptorTab extends PerceptorBase {
   public async run(): Promise<void> {
     // avoid redundant clone

--- a/src/pages/ContentScripts/PerceptorTab.tsx
+++ b/src/pages/ContentScripts/PerceptorTab.tsx
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import * as pageDetect from 'github-url-detection';
 import { utils } from 'github-url-detection';
-import { isPerceptor, runsWhen, isPublic } from '../../utils/utils';
+import { isPerceptor, runsWhen, isPublicRepo } from '../../utils/utils';
 import PerceptorBase from './PerceptorBase';
 import { inject2Perceptor } from './Perceptor';
 import { render } from 'react-dom';
@@ -9,7 +9,7 @@ import React from 'react';
 import TeachingBubbleWrapper from './TeachingBubbleWrapper';
 import logger from '../../utils/logger';
 
-@runsWhen([pageDetect.isRepo, isPublic])
+@runsWhen([isPublicRepo])
 class PerceptorTab extends PerceptorBase {
   public async run(): Promise<void> {
     // avoid redundant clone

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import messages_en from '../locales/en/messages.json';
 import messages_zh_CN from '../locales/zh_CN/messages.json';
+import * as pageDetect from 'github-url-detection';
 
 const messages_locale = {
   en: messages_en,
@@ -168,6 +169,6 @@ export function linearMap(
 }
 
 // check if the repository is public
-export function isPublic() {
-  return $('[class="Label Label--secondary v-align-middle mr-1"]')[0].innerHTML.toLowerCase() == "public";
+export function isPublicRepo() {
+  return pageDetect.isRepo() && $('[class="Label Label--secondary v-align-middle mr-1"]')[0].innerHTML.toLowerCase() == "public";
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -166,3 +166,8 @@ export function linearMap(
 
   return ((val - d0) / subDomain) * subRange + r0;
 }
+
+// check if the repository is public
+export function isPublic() {
+  return $('[class="Label Label--secondary v-align-middle mr-1"]')[0].innerHTML.toLowerCase() == "public";
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -170,5 +170,10 @@ export function linearMap(
 
 // check if the repository is public
 export function isPublicRepo() {
-  return pageDetect.isRepo() && $('[class="Label Label--secondary v-align-middle mr-1"]')[0].innerHTML.toLowerCase() == "public";
-};
+  return (
+    pageDetect.isRepo() &&
+    $(
+      '[class="Label Label--secondary v-align-middle mr-1"]'
+    )[0].innerHTML.toLowerCase() == 'public'
+  );
+}


### PR DESCRIPTION
## Purpose

This PR is initiated by https://github.com/hypertrons/hypertrons-crx/issues/276

#### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Approach

_How does this change address the problem?_

I created a new function `isPublic` to check the visibility of the current repository. The function simply compares the content of the top-left secondary label and return a Boolean. And I added `isPublic` to the `runsWhen` rules of `PerceptorTab` so that the feature would not be loaded on a private repository at `loadFeatures` phase.