### PR TITLE
[fix] prettier on windows OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "node utils/build.js",
     "start": "node utils/server.js",
-    "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss}'"
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,scss}\""
   },
   "dependencies": {
     "@antv/g6": "^4.5.5",


### PR DESCRIPTION
## Purpose

#325 

## Proposed changes

In the PR, I improved the working environment for developers who work on Windows OS

#### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Approach

1. Replacing single quote with double quote and an escape character works!
2. It is proved to be the `eof` problem and I added a new file `.gitattributes` to solve it based on [Options Prettier](https://prettier.io/docs/en/options.html#end-of-line) and [.gitattributes in Prettier](https://github.com/prettier/prettier/blob/main/.gitattributes).

## Other things to mention
1. As for the `eof` problem, it also can be solved by adding attributes to the `.prettierrc` or by adding options to the prettier command. However, based on the links I mentioned above, I selected to add a `.gitattributes` file.
2. Windows users may need to re-clone their repo to enable this change to be effective.
3. More tests may be needed.