### PR TITLE
chore: update urls in update_information.json

### DIFF
--- a/publish/update_information.json
+++ b/publish/update_information.json
@@ -1,11 +1,11 @@
 {
   "chrome": {
     "latest_version": "1.5.5",
-    "url": "https://chrome.google.com/webstore/detail/hypertrons-crx/jkgfcnkgfapbckbpgobmgiphpknkiljm"
+    "url": "https://chrome.google.com/webstore/detail/hypercrx/ijchfbpdgeljmhnhokmekkecpbdkgabc"
   },
   "edge": {
     "latest_version": "1.5.5",
-    "url": "https://microsoftedge.microsoft.com/addons/detail/hypertronscrx/lfdjlbagcbpjpdhlllcgglplcccnigip"
+    "url": "https://microsoftedge.microsoft.com/addons/detail/hypercrx/lbbajaehiibofpconjgdjonmkidpcome"
   },
   "develop": {
     "latest_version": "1.5.5",


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [x] others

Related issues:

- fixes #365

## Details
<!-- What did you do in this PR?  -->
The urls in update_information.json are outdated, which will take users to wrong sites. So update them with the right links.

<img width="903" alt="image" src="https://user-images.githubusercontent.com/32434520/171834921-4dd24005-5bc8-4c41-aed5-09de41f350cd.png">

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)
- [x] I have run `yarn run prettier` before creating this PR

## Others
<!-- Other information you want to share.  -->
(None)