### PR TITLE
fix: fatal issue 382

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,7 @@
       "matches": []
     }
   ],
-  "permissions": ["storage", "notifications", "alarms", "cookies"],
+  "permissions": ["storage", "notifications", "alarms", "cookies", "tabs"],
   "host_permissions": ["*://github.com/*"],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,8 +20,12 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["content.styles.css", "main.png"],
-      "matches": []
+      "resources": [
+        "content.styles.css",
+        "main.png",
+        "injectedScript.bundle.js"
+      ],
+      "matches": ["<all_urls>"]
     }
   ],
   "permissions": ["storage", "notifications", "alarms", "cookies", "tabs"],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,7 +28,7 @@
       "matches": ["<all_urls>"]
     }
   ],
-  "permissions": ["storage", "notifications", "alarms", "cookies", "tabs"],
+  "permissions": ["storage", "notifications", "alarms", "cookies"],
   "host_permissions": ["*://github.com/*"],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -95,26 +95,3 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // must return true in async mode
   return true;
 });
-
-const tabIds = new Set();
-
-// add contentscript's tabId to the set
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message === 'Hey background, take my tabId!') {
-    console.log('From contentscript: Hey background, take my tabId!');
-    if (sender.tab && sender.tab.id) {
-      tabIds.add(sender.tab.id);
-      sendResponse('Hey contentscript, copy that!');
-    }
-  }
-  // must return true in async mode
-  return true;
-});
-
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (tabIds.has(tabId)) {
-    if (changeInfo.url) {
-      chrome.tabs.sendMessage(tabId, 'url changed');
-    }
-  }
-});

--- a/src/pages/ContentScripts/DeveloperActiInflTrend.tsx
+++ b/src/pages/ContentScripts/DeveloperActiInflTrend.tsx
@@ -119,19 +119,35 @@ class DeveloperActiInflTrend extends PerceptorBase {
   }
 
   public async run(): Promise<void> {
-    const profileArea = $('.js-profile-editable-area').parent();
-    const newContainer = document.createElement('div');
-    newContainer.id = 'developer-acti-infl-trend';
-    newContainer.style.width = '100%';
     this._currentDeveloper = $('.p-nickname.vcard-username.d-block')
       .text()
       .trim();
 
-    render(
-      <DeveloperActiInflTrendView currentDeveloper={this._currentDeveloper} />,
-      newContainer
-    );
-    profileArea.after(newContainer);
+    let profileArea = null;
+    let newContainer = null;
+
+    // if exists (when going backword or forward in browser history)
+    if (document.getElementById('developer-acti-infl-trend') != null) {
+      render(
+        <DeveloperActiInflTrendView
+          currentDeveloper={this._currentDeveloper}
+        />,
+        document.getElementById('developer-acti-infl-trend')
+      );
+    } else {
+      profileArea = $('.js-profile-editable-area').parent();
+      newContainer = document.createElement('div');
+      newContainer.id = 'developer-acti-infl-trend';
+      newContainer.style.width = '100%';
+
+      render(
+        <DeveloperActiInflTrendView
+          currentDeveloper={this._currentDeveloper}
+        />,
+        newContainer
+      );
+      profileArea.after(newContainer);
+    }
   }
 }
 

--- a/src/pages/ContentScripts/DeveloperNetwork.tsx
+++ b/src/pages/ContentScripts/DeveloperNetwork.tsx
@@ -366,22 +366,38 @@ class DeveloperNetwork extends PerceptorBase {
   }
 
   public async run(): Promise<void> {
-    const profileArea = $('.js-profile-editable-area').parent();
-    const DeveloperNetworkDiv = document.createElement('div');
-    DeveloperNetworkDiv.id = 'developer-network';
-    DeveloperNetworkDiv.style.width = '100%';
     this._currentDeveloper = $('.p-nickname.vcard-username.d-block')
       .text()
       .trim();
+
+    let profileArea = null;
+    let DeveloperNetworkDiv = null;
+
     const settings = await loadSettings();
-    render(
-      <DeveloperNetworkView
-        currentDeveloper={this._currentDeveloper}
-        graphType={settings.graphType}
-      />,
-      DeveloperNetworkDiv
-    );
-    profileArea.after(DeveloperNetworkDiv);
+
+    // if exists (when going backword or forward in browser history)
+    if (document.getElementById('developer-network') != null) {
+      render(
+        <DeveloperNetworkView
+          currentDeveloper={this._currentDeveloper}
+          graphType={settings.graphType}
+        />,
+        document.getElementById('developer-network')
+      );
+    } else {
+      profileArea = $('.js-profile-editable-area').parent();
+      DeveloperNetworkDiv = document.createElement('div');
+      DeveloperNetworkDiv.id = 'developer-network';
+      DeveloperNetworkDiv.style.width = '100%';
+      render(
+        <DeveloperNetworkView
+          currentDeveloper={this._currentDeveloper}
+          graphType={settings.graphType}
+        />,
+        DeveloperNetworkDiv
+      );
+      profileArea.after(DeveloperNetworkDiv);
+    }
   }
 }
 

--- a/src/pages/ContentScripts/PerceptorLayout.tsx
+++ b/src/pages/ContentScripts/PerceptorLayout.tsx
@@ -11,9 +11,7 @@ const PerceptorLayoutView: React.FC = () => {
 class PerceptorLayout extends PerceptorBase {
   public async run(): Promise<void> {
     // remove the original container
-    const parentContainer = $('#repo-content-pjax-container').children(
-      'div.clearfix.container-xl'
-    );
+    const parentContainer = $('div.clearfix.container-xl:first');
     parentContainer.children('div.Layout').remove();
 
     // create the new one : percepter container

--- a/src/pages/ContentScripts/ProjectNetwork.tsx
+++ b/src/pages/ContentScripts/ProjectNetwork.tsx
@@ -264,20 +264,36 @@ class ProjectNetwork extends PerceptorBase {
     this._currentRepo = '';
   }
   public async run(): Promise<void> {
-    const perceptorContainer = $('#perceptor-layout').children();
-    const ProjectNetworkDiv = document.createElement('div');
-    ProjectNetworkDiv.id = 'project-network';
-    ProjectNetworkDiv.style.width = '100%';
     this._currentRepo = utils.getRepositoryInfo(window.location)!.nameWithOwner;
+
+    let perceptorContainer = null;
+    let ProjectNetworkDiv = null;
+
     const settings = await loadSettings();
-    render(
-      <ProjectNetworkView
-        currentRepo={this._currentRepo}
-        graphType={settings.graphType}
-      />,
-      ProjectNetworkDiv
-    );
-    perceptorContainer.prepend(ProjectNetworkDiv);
+
+    // if exists (when going backword or forward in browser history)
+    if (document.getElementById('project-network') != null) {
+      render(
+        <ProjectNetworkView
+          currentRepo={this._currentRepo}
+          graphType={settings.graphType}
+        />,
+        document.getElementById('project-network')
+      );
+    } else {
+      perceptorContainer = $('#perceptor-layout').children();
+      ProjectNetworkDiv = document.createElement('div');
+      ProjectNetworkDiv.id = 'project-network';
+      ProjectNetworkDiv.style.width = '100%';
+      render(
+        <ProjectNetworkView
+          currentRepo={this._currentRepo}
+          graphType={settings.graphType}
+        />,
+        ProjectNetworkDiv
+      );
+      perceptorContainer.prepend(ProjectNetworkDiv);
+    }
   }
 }
 

--- a/src/pages/ContentScripts/index.ts
+++ b/src/pages/ContentScripts/index.ts
@@ -32,3 +32,16 @@ async function mainInject() {
 }
 
 mainInject();
+
+// send a message to indirectly tell background this contentscript's tabId
+chrome.runtime.sendMessage('Hey background, take my tabId!', (response) => {
+  if (response === 'Hey contentscript, copy that!') {
+    console.log('From background: Hey contentscript, copy that!');
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message === 'url changed') {
+    mainInject();
+  }
+});

--- a/src/pages/ContentScripts/index.ts
+++ b/src/pages/ContentScripts/index.ts
@@ -39,17 +39,10 @@ async function mainInject() {
   }
 }
 
-mainInject();
-
-// send a message to indirectly tell background this contentscript's tabId
-chrome.runtime.sendMessage('Hey background, take my tabId!', (response) => {
-  if (response === 'Hey contentscript, copy that!') {
-    console.log('From background: Hey contentscript, copy that!');
-  }
-});
-
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message === 'url changed') {
+window.addEventListener('message', function (event) {
+  // Only accept messages from the same frame
+  if (event.source !== window) return;
+  if (event.data === 'turbo:load') {
     mainInject();
   }
 });

--- a/src/pages/ContentScripts/index.ts
+++ b/src/pages/ContentScripts/index.ts
@@ -1,3 +1,11 @@
+const injected = document.createElement('script');
+injected.src = chrome.runtime.getURL('injectedScript.bundle.js');
+console.log(injected);
+injected.onload = function () {
+  injected.remove();
+};
+(document.head || document.documentElement).appendChild(injected);
+
 // initializeIcons() should only be called once per app and must be called before rendering any components.
 import { initializeIcons } from '@fluentui/react/lib/Icons';
 initializeIcons();

--- a/src/pages/ContentScripts/index.ts
+++ b/src/pages/ContentScripts/index.ts
@@ -1,8 +1,13 @@
+// content script lives in an isolated world, which means it
+// cannot access to host page's javascript context such as
+// adding an extra event handler to a registered event in host
+// page. However, we can use injected scripts to run some code
+// that can access to host page's context.
 const injected = document.createElement('script');
 injected.src = chrome.runtime.getURL('injectedScript.bundle.js');
 console.log(injected);
 injected.onload = function () {
-  injected.remove();
+  injected.remove(); // after the script run, it can be removed
 };
 (document.head || document.documentElement).appendChild(injected);
 
@@ -23,6 +28,7 @@ import Hypertrons from './Hypertrons';
 
 import './content.styles.css';
 
+// inject to Perceptor's static variable
 inject2Perceptor(DeveloperActiInflTrend);
 inject2Perceptor(RepoActiInflTrend);
 inject2Perceptor(PerceptorTab);
@@ -39,6 +45,7 @@ async function mainInject() {
   }
 }
 
+// if receive "turbo:load" from injected script, run mainInject()
 window.addEventListener('message', function (event) {
   // Only accept messages from the same frame
   if (event.source !== window) return;

--- a/src/pages/InjectedScripts/index.ts
+++ b/src/pages/InjectedScripts/index.ts
@@ -1,0 +1,7 @@
+document.addEventListener('turbo:before-visit', () => {
+  [...document.getElementsByTagName('style')].forEach((element, index) => {
+    if (element.hasAttribute('data-merge-styles')) {
+      element.setAttribute('data-id', index + '');
+    }
+  });
+});

--- a/src/pages/InjectedScripts/index.ts
+++ b/src/pages/InjectedScripts/index.ts
@@ -5,3 +5,7 @@ document.addEventListener('turbo:before-visit', () => {
     }
   });
 });
+
+document.addEventListener('turbo:load', () => {
+  window.postMessage('turbo:load', '*');
+});

--- a/src/pages/InjectedScripts/index.ts
+++ b/src/pages/InjectedScripts/index.ts
@@ -1,3 +1,28 @@
+// This is an injected script, which shares same js context with the host page.
+
+// I infer that GitHub uses hotwired/turbo to speedup its SPA.
+// Fortunately there are some events to hook our code in GitHub
+// life cycle. See: https://turbo.hotwired.dev/reference/events
+
+// FluentUI is a css-in-js UI library, all styles are dynamicly
+// computed and injected to several style tags, like:
+//
+// <head>
+//   <style data-merge-styles="true"></style>
+//   <style data-merge-styles="true"></style>
+//   <style data-merge-styles="true"></style>
+// </head>
+//
+// Thease tags are only computed once for each component. But the
+// style tags are regarded as "provisional elements" by turbo and
+// most of them will be removed after each trubo:visit, leading to
+// style crash.
+//
+// After reading the source code of turbo, I figure out a workaround.
+// By adding an id to all <style data-merge-styles="true"></style>
+// to make their outerHtml not be same, turbo will not regard them
+// as provisional elements and will keep them in headers.
+
 document.addEventListener('turbo:before-visit', () => {
   [...document.getElementsByTagName('style')].forEach((element, index) => {
     if (element.hasAttribute('data-merge-styles')) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,11 +50,18 @@ let options = {
       'ContentScripts',
       'index.ts'
     ),
+    injectedScript: path.join(
+      __dirname,
+      'src',
+      'pages',
+      'InjectedScripts',
+      'index.ts'
+    ),
   },
   // "custom" is not a standard key of webpack options
   // it will be consumed by utils/server.js and must be deleted before webpack(config)
   custom: {
-    notHMR: ['background', 'contentScript'],
+    notHMR: ['background', 'contentScript', 'injectedScript'],
     enableBackgroundAutoReload: true, // always true when "enableContentScriptsAutoReload" is set true
     enableContentScriptsAutoReload: true,
   },


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [x] refactoring

Related issues:

- #382 

## Details

It seems navigating between GitHub Tabs/pages will not trigger page reload anymore (like a SPA), which causes that our contentscript will only be run once when we open a tab that matches GitHub url and it damages our extension's core injection function since the contentscript of Hypercrx is designed to be run multiple times for each time the pages are redirected.

Currently, to address this fatal problem, the message passing API supported by chrome extension is applied to trigger `mainInject()` when the url of that tab is changed. The new strategy works but is encountered with unexpected css styles problem. 

All fluentUI elements behave bad after second, third or more `mainInject()` runs, like this:

![image](https://user-images.githubusercontent.com/32434520/177965011-d0abc724-1524-47b2-8b02-68584deb45c0.png)

![image](https://user-images.githubusercontent.com/32434520/177965021-137b7315-7acd-4a6d-a266-620432441cac.png)

I spent whole day but did not figure out a solution. This only happens on fluentUI elements. I have tried antd library today and find it works well under the new strategy.:

![image](https://user-images.githubusercontent.com/32434520/177965718-c9f2218f-983f-4e99-b33d-7ccb7016455a.png)

Maybe we should transfer to other UI library? I have no idea :(

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others

fluentUI elemtens' class names are dynamic like:

![image](https://user-images.githubusercontent.com/32434520/177966049-f28908d2-6710-4d1f-80cc-d2d024985ee2.png)

When second `mainInject()` is run, all fluentUI classes disappear.
