### PR TITLE
chore: replace deprecated property "gap"

### DIFF
--- a/src/pages/ContentScripts/Hypertrons.tsx
+++ b/src/pages/ContentScripts/Hypertrons.tsx
@@ -196,7 +196,7 @@ const HypertronsTabView: React.FC<HypertronsTabViewProps> = ({
           </Text>
           <Stack
             className={styles.buttons}
-            gap={8}
+            tokens={{ childrenGap: 8 }}
             horizontal
             horizontalAlign="center"
             wrap


### PR DESCRIPTION
replace deprecated property "gap" of Stack with the latest counterpart "childrenGap"

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others

Related issues:

#408 
<!--
- #xxx
-->

## Details
<!-- What did you do in this PR?  -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
