### PR TITLE
ci: automatically deploy to edge add-on store

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -50,3 +50,7 @@ jobs:
           CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
           CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_CLIENT_SECRET: ${{ secrets.EDGE_CLIENT_SECRET }}
+          EDGE_ACCESS_TOKEN_URL: ${{ secrets.EDGE_ACCESS_TOKEN_URL }}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
+    "@plasmohq/edge-addons-api": "^1.0.1",
     "@types/chrome": "^0.0.177",
     "@types/jest": "^27.4.0",
     "@types/jquery": "^3.5.13",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,4 +1,5 @@
 import chromeWebstoreUpload from 'chrome-webstore-upload';
+import { EdgeAddonsAPI } from '@plasmohq/edge-addons-api';
 import { fileURLToPath } from 'url';
 import path, { dirname } from 'path';
 import fs from 'fs';
@@ -13,8 +14,15 @@ const CHROME_EXTENSION_ID = process.env.CHROME_EXTENSION_ID;
 const CHROME_CLIENT_ID = process.env.CHROME_CLIENT_ID;
 const CHROME_CLIENT_SECRET = process.env.CHROME_CLIENT_SECRET;
 const CHROME_REFRESH_TOKEN = process.env.CHROME_REFRESH_TOKEN;
+const EDGE_PRODUCT_ID = process.env.EDGE_PRODUCT_ID;
+const EDGE_CLIENT_ID = process.env.EDGE_CLIENT_ID;
+const EDGE_CLIENT_SECRET = process.env.EDGE_CLIENT_SECRET;
+const EDGE_ACCESS_TOKEN_URL = process.env.EDGE_ACCESS_TOKEN_URL;
 
-const store = chromeWebstoreUpload({
+// upload to chrome webstore
+console.log('Start deploying to chrome webstore...');
+
+const chromeStore = chromeWebstoreUpload({
   extensionId: CHROME_EXTENSION_ID,
   clientId: CHROME_CLIENT_ID,
   clientSecret: CHROME_CLIENT_SECRET,
@@ -24,11 +32,26 @@ const store = chromeWebstoreUpload({
 const zipFile = fs.createReadStream(ZIP_PATH);
 
 (async () => {
-  const token = await store.fetchToken();
+  const token = await chromeStore.fetchToken();
 
-  const uploadRes = await store.uploadExisting(zipFile, token);
+  const uploadRes = await chromeStore.uploadExisting(zipFile, token);
   console.log({ uploadRes });
 
-  const publishRes = await store.publish('default', token);
+  const publishRes = await chromeStore.publish('default', token);
   console.log({ publishRes });
 })();
+
+// upload to edge add-on store
+console.log('Start deploying to edge add-on store...');
+
+const edgeStore = new EdgeAddonsAPI({
+  productId: EDGE_PRODUCT_ID,
+  clientId: EDGE_CLIENT_ID,
+  clientSecret: EDGE_CLIENT_SECRET,
+  accessTokenUrl: EDGE_ACCESS_TOKEN_URL,
+});
+
+await edgeStore.submit({
+  filePath: ZIP_PATH,
+  notes: 'Updating extension.',
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,6 +1608,13 @@
   dependencies:
     "@octokit/openapi-types" "^12.4.0"
 
+"@plasmohq/edge-addons-api@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmmirror.com/@plasmohq/edge-addons-api/-/edge-addons-api-1.0.1.tgz#509243c24df1089a933941f5b2e4103522eab1ae"
+  integrity sha512-KXGTXaxQEofYjoDLnS1Uzz896X+76kNZkCWZhGPWVtuHuhg09JEAZdG3sWOA7tPCY5zVOD1xFbzhylF7Yt/S/A==
+  dependencies:
+    got "12.1.0"
+
 "@probe.gl/env@3.5.0":
   version "3.5.0"
   resolved "https://registry.npmjs.org/@probe.gl/env/-/env-3.5.0.tgz"
@@ -1630,7 +1637,7 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-"@sindresorhus/is@^4.0.0":
+"@sindresorhus/is@^4.0.0", "@sindresorhus/is@^4.6.0":
   version "4.6.0"
   resolved "https://registry.npmmirror.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
@@ -1641,6 +1648,13 @@
   integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
   dependencies:
     defer-to-connect "^2.0.0"
+
+"@szmarczak/http-timer@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-5.0.1.tgz#c7c1bf1141cdd4751b0399c8fc7b8b664cd5be3a"
+  integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
+  dependencies:
+    defer-to-connect "^2.0.1"
 
 "@types/body-parser@*":
   version "1.19.2"
@@ -1657,7 +1671,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cacheable-request@^6.0.1":
+"@types/cacheable-request@^6.0.1", "@types/cacheable-request@^6.0.2":
   version "6.0.2"
   resolved "https://registry.npmmirror.com/@types/cacheable-request/-/cacheable-request-6.0.2.tgz#c324da0197de0a98a2312156536ae262429ff6b9"
   integrity sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==
@@ -2508,6 +2522,11 @@ cacheable-lookup@^5.0.3:
   resolved "https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
   integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
 
+cacheable-lookup@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz#65c0e51721bb7f9f2cb513aed6da4a1b93ad7dc8"
+  integrity sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A==
+
 cacheable-request@^7.0.2:
   version "7.0.2"
   resolved "https://registry.npmmirror.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
@@ -2959,7 +2978,7 @@ default-gateway@^6.0.3:
   dependencies:
     execa "^5.0.0"
 
-defer-to-connect@^2.0.0:
+defer-to-connect@^2.0.0, defer-to-connect@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
@@ -3386,6 +3405,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
+form-data-encoder@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.npmmirror.com/form-data-encoder/-/form-data-encoder-1.7.1.tgz#ac80660e4f87ee0d3d3c3638b7da8278ddb8ec96"
+  integrity sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==
+
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz"
@@ -3451,7 +3475,7 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -3530,6 +3554,25 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+got@12.1.0:
+  version "12.1.0"
+  resolved "https://registry.npmmirror.com/got/-/got-12.1.0.tgz#099f3815305c682be4fd6b0ee0726d8e4c6b0af4"
+  integrity sha512-hBv2ty9QN2RdbJJMK3hesmSkFTjVIHyIDDbssCKnSmq62edGgImJWD10Eb1k77TiV1bxloxqcFAVK8+9pkhOig==
+  dependencies:
+    "@sindresorhus/is" "^4.6.0"
+    "@szmarczak/http-timer" "^5.0.1"
+    "@types/cacheable-request" "^6.0.2"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^6.0.4"
+    cacheable-request "^7.0.2"
+    decompress-response "^6.0.0"
+    form-data-encoder "1.7.1"
+    get-stream "^6.0.1"
+    http2-wrapper "^2.1.10"
+    lowercase-keys "^3.0.0"
+    p-cancelable "^3.0.0"
+    responselike "^2.0.0"
 
 got@^11.8.2:
   version "11.8.5"
@@ -3731,6 +3774,14 @@ http2-wrapper@^1.0.0-beta.5.2:
   dependencies:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
+
+http2-wrapper@^2.1.10:
+  version "2.1.11"
+  resolved "https://registry.npmmirror.com/http2-wrapper/-/http2-wrapper-2.1.11.tgz#d7c980c7ffb85be3859b6a96c800b2951ae257ef"
+  integrity sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.2.0"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -4160,6 +4211,11 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lowercase-keys@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
+  integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"
@@ -4504,6 +4560,11 @@ p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
   integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
+
+p-cancelable@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmmirror.com/p-cancelable/-/p-cancelable-3.0.0.tgz#63826694b54d61ca1c20ebcb6d3ecf5e14cd8050"
+  integrity sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -5015,7 +5076,7 @@ requires-port@^1.0.0:
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
-resolve-alpn@^1.0.0:
+resolve-alpn@^1.0.0, resolve-alpn@^1.2.0:
   version "1.2.1"
   resolved "https://registry.npmmirror.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
   integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] ci

Related issues:

- resolve #290

## Details
<!-- What did you do in this PR?  -->
Related [test workflow](https://github.com/tyn1998/workflows-for-hypercrx/runs/7478287061?check_suite_focus=true)：

![image](https://user-images.githubusercontent.com/32434520/180589112-0dc22df0-39f2-47de-85f1-decf6cfdbd52.png)

New secrets:

![image](https://user-images.githubusercontent.com/32434520/180589893-3545d3ba-c810-4706-aded-c85f1c921472.png)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
Well, since I tested the workflow in real environment, a generated 1.7.0 version was uploaded to both chrome webstore and edge add-on store. This is bad, since we cannot upload a smaller version to stores if a bigger version is published.

But fortunately, in edge store we can cancel a publish, and in chrome store we can [defer](https://developer.chrome.com/docs/webstore/publish/#:~:text=%23%20Deferred%20publishing%20option&text=If%20you%20uncheck%20the%20checkbox,once%20the%20review%20is%20complete.) a publish to manually publish it or [drop it](https://stackoverflow.com/a/68568217/10369621) after passing the review.

In addition, chrome store doesn't allow upload with smaller or equal version number, while edge store allows it when upload but rejects when publish.