### PR TITLE
ci: release body with contributor login name

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           artifacts: "release/hypercrx.*"
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.changelog.outputs.tag }}
-          body: ${{ steps.changelog.outputs.clean_changelog }}
+          generateReleaseNotes: true
 
       - name: Deploy
         run: |


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] ci

Related issues:

- resolve #388 

## Details

Refer to https://github.com/ncipollo/release-action#action-inputs:

<img width="780" alt="image" src="https://user-images.githubusercontent.com/32434520/180597556-eb0aeef6-d214-4074-a3a6-78eb523e5e4b.png">

Only commits corresponding to PRs that in **current repo** will be generated as release body, waste so much time here :(

![image](https://user-images.githubusercontent.com/32434520/180597622-a9b61132-6f2c-4cd4-915e-b1bd12d1ae5a.png)


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
N.A.