### PR TITLE
ci: release file names with version number

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -31,13 +31,18 @@ jobs:
           yarn install
           yarn run build
 
-      - name: zip to hypercrx.zip
-        run: zip release/hypercrx.zip -r build/*
+      - name: Zip to hypercrx.zip
+        run: zip -j release/hypercrx.zip build/*
+
+      - name: Append version to release file names
+        run: |
+          cp release/hypercrx.crx ${{format('release/hypercrx-{0}.crx', steps.changelog.outputs.tag)}}
+          cp release/hypercrx.zip ${{format('release/hypercrx-{0}.zip', steps.changelog.outputs.tag)}}
 
       - name: Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "release/hypercrx.*"
+          artifacts: "release/hypercrx-v*.*"
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.changelog.outputs.tag }}
           generateReleaseNotes: true


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] ci

Related issues:

- resolve #387

## Details
<!-- What did you do in this PR?  -->
Now files in release assets have version suffix and all compressed files are in zip root dir:

![image](https://user-images.githubusercontent.com/32434520/180609695-9ebce82e-5c36-40ff-a715-3495839e7fae.png)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
Related test workflow run:

- https://github.com/tyn1998/workflows-for-hypercrx/actions/runs/2723977708