### PR TITLE
fix: use `query` to fiter events of Echarts

### DIFF
--- a/src/components/Graph/Echarts/index.tsx
+++ b/src/components/Graph/Echarts/index.tsx
@@ -21,7 +21,13 @@ interface EChartsWrapperProps {
   /**
    * bind events, default is `{}`
    */
-  readonly onEvents?: Record<string, Function>;
+  readonly onEvents?: Record<
+    string,
+    {
+      query?: string | Object;
+      handler: Function;
+    }
+  >;
 }
 
 const EChartsWrapper: React.FC<EChartsWrapperProps> = ({
@@ -59,11 +65,6 @@ const EChartsWrapper: React.FC<EChartsWrapperProps> = ({
    * render and return a new echart instance
    */
   const renderNewEcharts = () => {
-    const bindEvent = (eventName: string, func: Function) => {
-      instance.on(eventName, (param: any) => {
-        func(param.data);
-      });
-    };
     const instance = getEchartsInstance();
     instance.setOption(option);
     window.addEventListener('resize', () => {
@@ -72,7 +73,17 @@ const EChartsWrapper: React.FC<EChartsWrapperProps> = ({
     // loop and bind events
     for (const eventName in onEvents) {
       if (Object.prototype.hasOwnProperty.call(onEvents, eventName)) {
-        bindEvent(eventName, onEvents[eventName]);
+        const query = onEvents[eventName].query;
+        const handler = onEvents[eventName].handler;
+        if (query) {
+          instance.on(eventName, query, (param: any) => {
+            handler(param.data);
+          });
+        } else {
+          instance.on(eventName, (param: any) => {
+            handler(param.data);
+          });
+        }
       }
     }
   };

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -188,7 +188,12 @@ const Graph: React.FC<GraphProps> = ({
           option={graphOption}
           style={style}
           onEvents={{
-            click: onNodeClick,
+            click: {
+              query: {
+                dataType: 'node',
+              },
+              handler: onNodeClick,
+            },
           }}
         />
       </Stack>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

Related issues:

- fix #465

## Details
<!-- What did you do in this PR?  -->

I used [`query`](https://echarts.apache.org/zh/api.html#echartsInstance.on) option provided by Echarts to filter those unwanted events.

Now clicking edges won't trigger events:

![2022-10-03 10 15 35](https://user-images.githubusercontent.com/32434520/193490049-babf9e8b-3ca0-4f52-ad47-8fb78b1088f6.gif)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
