### PR TITLE
fix: modify the css class of the two network buttons in profile perceptor to avoid be truncated

### DIFF
--- a/src/views/DeveloperNetworkView/DeveloperNetworkView.tsx
+++ b/src/views/DeveloperNetworkView/DeveloperNetworkView.tsx
@@ -143,10 +143,7 @@ const DeveloperNetworkView: React.FC<DeveloperNetworkViewProps> = ({
     <div className="border-top color-border-secondary pt-3 mt-3">
       <h2 className="h4 mb-2">Perceptor</h2>
       <ul className="vcard-details">
-        <li
-          className="vcard-detail pt-1 css-truncate css-truncate-target"
-          style={{ margin: '-5px -30px' }}
-        >
+        <li className="vcard-detail pt-1" style={{ margin: '-5px -30px' }}>
           <ActionButton
             iconProps={{ iconName: 'Group' }}
             onClick={() => {
@@ -174,10 +171,7 @@ const DeveloperNetworkView: React.FC<DeveloperNetworkViewProps> = ({
             </span>
           </ActionButton>
         </li>
-        <li
-          className="vcard-detail pt-1 css-truncate css-truncate-target"
-          style={{ margin: '-5px -30px' }}
-        >
+        <li className="vcard-detail pt-1" style={{ margin: '-5px -30px' }}>
           <ActionButton
             iconProps={{ iconName: 'BranchMerge' }}
             onClick={() => {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

Related issues:

- fix #478

## Details
<!-- What did you do in this PR?  -->
After removing several classes, everything seems good:

<img width="1207" alt="image" src="https://user-images.githubusercontent.com/32434520/196319352-51b1fe03-cbbf-4bbb-9b5b-4dfe164b5572.png">

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
