### PR TITLE
fix: bars of ActiInflTrend Chart not respond to click when language is English

### DIFF
--- a/src/views/RepoActiInflTrendView/RepoActiInflTrendView.tsx
+++ b/src/views/RepoActiInflTrendView/RepoActiInflTrendView.tsx
@@ -61,12 +61,8 @@ const RepoActiInflTrendView: React.FC<RepoActiInflTrendViewProps> = ({
   let barsData: any = generateBarsData(repoActiInflData);
 
   const onClick = (params: any) => {
-    const { seriesName, data } = params;
-    const yName = getMessageByLocale(
-      'component_repoActiInflTrend_yName1',
-      settings.locale
-    );
-    if (seriesName === yName) {
+    const { seriesIndex, data } = params;
+    if (seriesIndex === 0) {
       let [year, month] = data.toString().split(',')[0].split('-');
       if (month.length < 2) {
         month = '0' + month;


### PR DESCRIPTION

## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #430

## Details
<!-- What did you do in this PR?  -->
Actually the issue does not arise recently, it has been there since the feature came out. When the language is set to Chinese it works well but if we set the language to English the bug appears. Because in English, `seriesName`("Activity") is not equal to `yName`("Act"), the code within that `if` won't be executed.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
BTW, `seriesIndex` looks good to me now 😆 https://github.com/hypertrons/hypertrons-crx/pull/456#discussion_r971454350