### PR TITLE
fix: repoLabel is not recognized right

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -195,8 +195,10 @@ export function linearMap(
 
 // check if the repository is public
 export function isPublicRepo() {
+  // another selector that also works
+  // const repoLabel = $('strong[itemprop="name"]').siblings('span.Label.Label--secondary').text();
   const repoLabel = $('#repository-container-header')
-    .find('span.Label.Label--secondary')
+    .find('span.Label.Label--secondary:first')
     .text();
   return (
     pageDetect.isRepo() &&


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #504

## Details
<!-- What did you do in this PR?  -->
First I thought it was the change of GitHub UI that should be responsible for  the wrong tab highlight. However, that was not the truth after diving deeper into this issue.

The cause of the issue is in fact due to the popups feature(#455), which changes the DOM structure of the page then the `isPublicRepo()` detector is affected. More specifically, "Public11378" is extracted by the use of `.text()`, which concatenates all text of elements that are selected by a jQuery selector, while "Public" is expected!

<img width="702" alt="image" src="https://user-images.githubusercontent.com/32434520/200167257-1a11949c-c9cf-4c84-8f56-e650b749e49a.png">

So I add a `:first` filter to the original selector, now there is only the wanted element in that selecting result.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
