### PR TITLE
style: add dark mode for hypertron command pop up window

### DIFF
--- a/src/views/HypertronsView/HypertronsView.tsx
+++ b/src/views/HypertronsView/HypertronsView.tsx
@@ -180,8 +180,8 @@ const HypertronsView: React.FC<HypertronsTabViewProps> = ({
           directionalHint={DirectionalHint.topCenter}
           style={{
             padding: '20px 24px',
-            backgroundColor: githubTheme === 'light' ? 'white' : '#161B22',
           }}
+          backgroundColor={githubTheme === 'light' ? 'white' : '#161B22'}
         >
           <Text
             variant="xLarge"

--- a/src/views/HypertronsView/HypertronsView.tsx
+++ b/src/views/HypertronsView/HypertronsView.tsx
@@ -16,13 +16,18 @@ import {
   Label2Style,
   getUserNameFromCookie,
 } from '../../services/hypertrons';
-import { getMessageByLocale, runsWhen } from '../../utils/utils';
+import {
+  getGithubTheme,
+  getMessageByLocale,
+  runsWhen,
+} from '../../utils/utils';
 import Settings, { loadSettings } from '../../utils/settings';
+
+const githubTheme = getGithubTheme();
 
 const styles = mergeStyleSets({
   callout: {
     width: 360,
-    padding: '20px 24px',
   },
   title: {
     fontWeight: FontWeights.bold,
@@ -173,11 +178,23 @@ const HypertronsView: React.FC<HypertronsTabViewProps> = ({
           target={'#hypertrons_button'}
           onDismiss={toggleIsCalloutVisible}
           directionalHint={DirectionalHint.topCenter}
+          style={{
+            padding: '20px 24px',
+            backgroundColor: githubTheme === 'light' ? 'white' : '#161B22',
+          }}
         >
-          <Text variant="xLarge" block className={styles.title}>
+          <Text
+            variant="xLarge"
+            block
+            className={styles.title}
+            style={{ color: githubTheme === 'light' ? '#24292F' : '#C9D1D9' }}
+          >
             {getMessageByLocale('hypertrons_tab_title', settings.locale)}
           </Text>
-          <Text variant="medium" block>
+          <Text
+            variant="medium"
+            style={{ color: githubTheme === 'light' ? '#24292F' : '#C9D1D9' }}
+          >
             {getMessageByLocale('hypertrons_tab_description', settings.locale)}
             &nbsp;
             <Link


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] test
- [x] style

 Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- style #512 

## Details
<!-- What did you do in this PR?  -->
light mode screenshot
![light mode](https://user-images.githubusercontent.com/50283262/201015330-5106a2bb-5439-4ce3-9448-4ca644530391.png)

dark mode screenshot
![dark mode](https://user-images.githubusercontent.com/50283262/201015363-01ddb12e-ecb9-4db7-bc57-cc66a1603b6f.png)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
Thanks @wj23027  and @lucky_xmyu :) 
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
