### PR TITLE
fix: header labels cannot be triggered sometimes

### DIFF
--- a/src/anchors/RepoHeaderLabelsAnchor.tsx
+++ b/src/anchors/RepoHeaderLabelsAnchor.tsx
@@ -16,24 +16,26 @@ class RepoHeaderLabelsAnchor extends PerceptorBase {
   }
 
   public async run(): Promise<void> {
+    // Ideally, we should do nothing if the container already exists. But
+    // when I try to navigate back from profile page, I find tooltip won't
+    // show though the related element exists. I think there might be something
+    // else in javascript context, which is broken after navigation between
+    // pages. So instead of doing nothing, I remove the container and reload
+    // it again. At least this way works.
+    if ($('#repo-header-labels').length > 0) {
+      $('#repo-header-labels').remove();
+    }
+
     this._currentRepo = utils.getRepositoryInfo(window.location)!.nameWithOwner;
 
-    let container = null;
+    const container = document.createElement('div');
+    container.id = 'repo-header-labels';
 
-    // if not the first time to enter this code
-    if (document.getElementById('repo-header-labels') == null) {
-      container = document.createElement('div');
-      container.id = 'repo-header-labels';
+    render(<RepoHeaderLabelsView currentRepo={this._currentRepo} />, container);
 
-      render(
-        <RepoHeaderLabelsView currentRepo={this._currentRepo} />,
-        container
-      );
-
-      $('#repository-container-header')
-        .find('span.Label.Label--secondary')
-        .after(container);
-    }
+    $('#repository-container-header')
+      .find('span.Label.Label--secondary')
+      .after(container);
   }
 }
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #517

## Details
<!-- What did you do in this PR?  -->
Just adding an `if` branch like which is used in other popups will work. The reason that I didn't do this before is that I thought the header-related DOM elements will not change once the page is initialized. The truth is not.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
N.A.