### PR TITLE
perf: debounce echartsInstance.resize() to avoid pages becoming slow when window being resized

### DIFF
--- a/src/components/Graph/Echarts/index.tsx
+++ b/src/components/Graph/Echarts/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, CSSProperties } from 'react';
 import * as echarts from 'echarts';
+import { debounce } from '../../../utils/utils';
 
 interface EChartsWrapperProps {
   /**
@@ -67,9 +68,10 @@ const EChartsWrapper: React.FC<EChartsWrapperProps> = ({
   const renderNewEcharts = () => {
     const instance = getEchartsInstance();
     instance.setOption(option);
-    window.addEventListener('resize', () => {
+    const [debouncedResize, teardown] = debounce(() => {
       instance.resize();
-    });
+    }, 500);
+    window.addEventListener('resize', debouncedResize);
     // loop and bind events
     for (const eventName in onEvents) {
       if (Object.prototype.hasOwnProperty.call(onEvents, eventName)) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -205,3 +205,26 @@ export function isPublicRepo() {
     (repoLabel === 'Public' || repoLabel === 'Public template')
   );
 }
+
+// https://dev.to/bwca/create-a-debounce-function-from-scratch-in-typescript-560m
+export function debounce<A = unknown, R = void>(
+  fn: (args: A) => R,
+  ms: number
+): [(args: A) => Promise<R>, () => void] {
+  let timer: NodeJS.Timeout;
+
+  const debouncedFunc = (args: A): Promise<R> =>
+    new Promise((resolve) => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+
+      timer = setTimeout(() => {
+        resolve(fn(args));
+      }, ms);
+    });
+
+  const teardown = () => clearTimeout(timer);
+
+  return [debouncedFunc, teardown];
+}


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [x] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- resolve #533

## Details
<!-- What did you do in this PR?  -->
Turned `instance.resize()` into a debounce founction so now it will only be triggered 500ms after window resizing stops.


https://user-images.githubusercontent.com/32434520/203568515-950fc929-3717-4aa5-b17a-de2926da65cd.mp4



## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
N.A.