### PR TITLE
refactor: add wrapper to handle date formatting so json update in OpenDigger will not break Hypercrx

### DIFF
--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -2,8 +2,12 @@ export const generateDataByMonth = (originalData: any) => {
   const objectData: any = {};
   // format month string
   Object.keys(originalData).forEach((key) => {
-    // e.g. 20204 -> 2020-4
-    const date = key.slice(0, 4) + '-' + key.slice(4);
+    // following wrapper code is for adaption purpose, see issue #541
+    let date = key;
+    // handle old date format, e.g. 20204 -> 2020-4
+    if (!key.includes('-')) {
+      date = key.slice(0, 4) + '-' + key.slice(4);
+    }
     objectData[date] = originalData[key];
   });
   // get the oldest month and the newest one


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [x] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- resolve #541

## Details
<!-- What did you do in this PR?  -->
Now the old date format `yyyym(m)` and the new one `yyyy-mm` can both be correctly parsed so [the change](https://github.com/X-lab2017/open-digger/issues/1074) in OpenDigger will not break functions in Hypercrx.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
N.A.