### PR TITLE
fix: PR chart won't show if one of metric files doesn't exist

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,0 +1,25 @@
+import { OSS_XLAB_ENDPOINT, ErrorCode } from '../constant';
+import request from '../utils/request';
+
+export const getMetricByName = async (
+  owner: string,
+  metricNameMap: Map<string, string>,
+  metric: string
+) => {
+  try {
+    return await request(
+      `${OSS_XLAB_ENDPOINT}/open_digger/github/${owner}/${metricNameMap.get(
+        metric
+      )}.json`
+    );
+  } catch (error) {
+    // the catched error being "404" means the metric file is not available
+    // returning an empty object makes follow-up data processing easier
+    if (error === ErrorCode.NOT_FOUND) {
+      return {};
+    } else {
+      // other errors should be throwed
+      throw error;
+    }
+  }
+};

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -13,10 +13,9 @@ export const getMetricByName = async (
       )}.json`
     );
   } catch (error) {
-    // the catched error being "404" means the metric file is not available
-    // returning an empty object makes follow-up data processing easier
+    // the catched error being "404" means the metric file is not available so return a null
     if (error === ErrorCode.NOT_FOUND) {
-      return {};
+      return null;
     } else {
       // other errors should be throwed
       throw error;

--- a/src/api/developer.ts
+++ b/src/api/developer.ts
@@ -1,5 +1,4 @@
-import { OSS_XLAB_ENDPOINT } from '../constant';
-import request from '../utils/request';
+import { getMetricByName } from './common';
 
 // metric names and their implementation names in OpenDigger
 const metricNameMap = new Map([
@@ -9,27 +8,18 @@ const metricNameMap = new Map([
   ['repo_network', 'repo_network'],
 ]);
 
-const getMetricByName = async (user: string, metric: string) => {
-  const res = await request(
-    `${OSS_XLAB_ENDPOINT}/open_digger/github/${user}/${metricNameMap.get(
-      metric
-    )}.json`
-  );
-  return res.data;
-};
-
 export const getActivity = async (user: string) => {
-  return getMetricByName(user, 'activity');
+  return getMetricByName(user, metricNameMap, 'activity');
 };
 
 export const getOpenrank = async (user: string) => {
-  return getMetricByName(user, 'openrank');
+  return getMetricByName(user, metricNameMap, 'openrank');
 };
 
 export const getDeveloperNetwork = async (user: string) => {
-  return getMetricByName(user, 'developer_network');
+  return getMetricByName(user, metricNameMap, 'developer_network');
 };
 
 export const getRepoNetwork = async (user: string) => {
-  return getMetricByName(user, 'repo_network');
+  return getMetricByName(user, metricNameMap, 'repo_network');
 };

--- a/src/api/repo.ts
+++ b/src/api/repo.ts
@@ -1,5 +1,4 @@
-import { OSS_XLAB_ENDPOINT } from '../constant';
-import request from '../utils/request';
+import { getMetricByName } from './common';
 
 // metric names and their implementation names in OpenDigger
 const metricNameMap = new Map([
@@ -21,75 +20,66 @@ const metricNameMap = new Map([
   ['repo_network', 'repo_network'],
 ]);
 
-const getMetricByName = async (repo: string, metric: string) => {
-  const res = await request(
-    `${OSS_XLAB_ENDPOINT}/open_digger/github/${repo}/${metricNameMap.get(
-      metric
-    )}.json`
-  );
-  return res.data;
-};
-
 export const getActivity = async (repo: string) => {
-  return getMetricByName(repo, 'activity');
+  return getMetricByName(repo, metricNameMap, 'activity');
 };
 
 export const getOpenrank = async (repo: string) => {
-  return getMetricByName(repo, 'openrank');
+  return getMetricByName(repo, metricNameMap, 'openrank');
 };
 
 export const getParticipant = async (repo: string) => {
-  return getMetricByName(repo, 'participant');
+  return getMetricByName(repo, metricNameMap, 'participant');
 };
 
 export const getForks = async (repo: string) => {
-  return getMetricByName(repo, 'forks');
+  return getMetricByName(repo, metricNameMap, 'forks');
 };
 
 export const getStars = async (repo: string) => {
-  return getMetricByName(repo, 'stars');
+  return getMetricByName(repo, metricNameMap, 'stars');
 };
 
 export const getIssuesOpened = async (repo: string) => {
-  return getMetricByName(repo, 'issues_opened');
+  return getMetricByName(repo, metricNameMap, 'issues_opened');
 };
 
 export const getIssuesClosed = async (repo: string) => {
-  return getMetricByName(repo, 'issues_closed');
+  return getMetricByName(repo, metricNameMap, 'issues_closed');
 };
 
 export const getIssueComments = async (repo: string) => {
-  return getMetricByName(repo, 'issue_comments');
+  return getMetricByName(repo, metricNameMap, 'issue_comments');
 };
 
 export const getPROpened = async (repo: string) => {
-  return getMetricByName(repo, 'PR_opened');
+  return getMetricByName(repo, metricNameMap, 'PR_opened');
 };
 
 export const getPRMerged = async (repo: string) => {
-  return getMetricByName(repo, 'PR_merged');
+  return getMetricByName(repo, metricNameMap, 'PR_merged');
 };
 
 export const getPRReviews = async (repo: string) => {
-  return getMetricByName(repo, 'PR_reviews');
+  return getMetricByName(repo, metricNameMap, 'PR_reviews');
 };
 
 export const getMergedCodeAddition = async (repo: string) => {
-  return getMetricByName(repo, 'merged_code_addition');
+  return getMetricByName(repo, metricNameMap, 'merged_code_addition');
 };
 
 export const getMergedCodeDeletion = async (repo: string) => {
-  return getMetricByName(repo, 'merged_code_deletion');
+  return getMetricByName(repo, metricNameMap, 'merged_code_deletion');
 };
 
 export const getMergedCodeSum = async (repo: string) => {
-  return getMetricByName(repo, 'merged_code_sum');
+  return getMetricByName(repo, metricNameMap, 'merged_code_sum');
 };
 
 export const getDeveloperNetwork = async (repo: string) => {
-  return getMetricByName(repo, 'developer_network');
+  return getMetricByName(repo, metricNameMap, 'developer_network');
 };
 
 export const getRepoNetwork = async (repo: string) => {
-  return getMetricByName(repo, 'repo_network');
+  return getMetricByName(repo, metricNameMap, 'repo_network');
 };

--- a/src/components/ExceptionPage/ErrorPage.tsx
+++ b/src/components/ExceptionPage/ErrorPage.tsx
@@ -59,8 +59,8 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ errorCode }) => {
       <Stack.Item>
         <strong>{errMessageObj.measure.text}</strong>
         <ul style={{ margin: '15px 0 0 15px' }}>
-          {errMessageObj.measure.tips.map((tip: string) => {
-            return <li>{tip}</li>;
+          {errMessageObj.measure.tips.map((tip: string, index: number) => {
+            return <li key={index}>{tip}</li>;
           })}
         </ul>
       </Stack.Item>

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,4 +1,7 @@
 export const generateDataByMonth = (originalData: any) => {
+  if (originalData === null) {
+    return [];
+  }
   const orderedMonths = Object.keys(originalData).sort((a, b) => {
     const dateA = new Date(a);
     const dateB = new Date(b);

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,6 +1,3 @@
-// @ts-ignore
-import { ErrorCode } from '../constant';
-
 /**
  * @zh-CN 处理网络请求
  * @en-US network request
@@ -8,14 +5,10 @@ import { ErrorCode } from '../constant';
 const request = async (url: string) => {
   const response = await fetch(url);
   if (!response.ok) {
-    throw ErrorCode.NOT_FOUND;
+    throw response.status;
+  } else {
+    return await response.json();
   }
-  const data = await response.json();
-  return {
-    status: response.status,
-    statusText: response.statusText,
-    data,
-  };
 };
 
 export default request;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -221,3 +221,7 @@ export function debounce<A = unknown, R = void>(
 
   return [debouncedFunc, teardown];
 }
+
+export function isAllNull(obj: Object) {
+  return Object.values(obj).every((value) => value === null);
+}

--- a/src/views/DeveloperActORTrendView/DeveloperActORTrendView.tsx
+++ b/src/views/DeveloperActORTrendView/DeveloperActORTrendView.tsx
@@ -39,12 +39,8 @@ const DeveloperActORTrendView: React.FC<DeveloperActORTrendViewProps> = ({
 
   useEffect(() => {
     (async () => {
-      try {
-        setActivity(await getActivity(currentDeveloper));
-        setOpenrank(await getOpenrank(currentDeveloper));
-      } catch (e) {
-        console.error(e);
-      }
+      setActivity(await getActivity(currentDeveloper));
+      setOpenrank(await getOpenrank(currentDeveloper));
     })();
   }, []);
 

--- a/src/views/DeveloperNetworkView/DeveloperNetworkView.tsx
+++ b/src/views/DeveloperNetworkView/DeveloperNetworkView.tsx
@@ -37,11 +37,11 @@ const DeveloperNetworkView: React.FC<DeveloperNetworkViewProps> = ({
   // get developercollaboration data
   useEffect(() => {
     (async () => {
-      try {
-        setDeveloperNetwork(await getDeveloperNetwork(currentDeveloper));
-      } catch (e) {
-        // @ts-ignore
-        setStatusCode(e);
+      const data = await getDeveloperNetwork(currentDeveloper);
+      if (data !== null) {
+        setDeveloperNetwork(data);
+      } else {
+        setStatusCode(404);
       }
     })();
   }, [developerPeriod]);
@@ -49,11 +49,11 @@ const DeveloperNetworkView: React.FC<DeveloperNetworkViewProps> = ({
   // get participated projects data
   useEffect(() => {
     (async () => {
-      try {
-        setRepoNetwork(await getRepoNetwork(currentDeveloper));
-      } catch (e) {
-        // @ts-ignore
-        setStatusCode(e);
+      const data = await getRepoNetwork(currentDeveloper);
+      if (data !== null) {
+        setRepoNetwork(data);
+      } else {
+        setStatusCode(404);
       }
     })();
   }, [repoPeriod]);

--- a/src/views/ProjectNetworkView/ProjectNetworkView.tsx
+++ b/src/views/ProjectNetworkView/ProjectNetworkView.tsx
@@ -31,22 +31,22 @@ const ProjectNetworkView: React.FC<ProjectNetworkViewProps> = ({
 
   useEffect(() => {
     (async () => {
-      try {
-        setRepoNetwork(await getRepoNetwork(currentRepo));
-      } catch (e) {
-        // @ts-ignore
-        setStatusCode(e);
+      const data = await getRepoNetwork(currentRepo);
+      if (data !== null) {
+        setRepoNetwork(data);
+      } else {
+        setStatusCode(404);
       }
     })();
   }, [repoPeriod]);
 
   useEffect(() => {
     (async () => {
-      try {
-        setDeveloperNetwork(await getDeveloperNetwork(currentRepo));
-      } catch (e) {
-        // @ts-ignore
-        setStatusCode(e);
+      const data = await getDeveloperNetwork(currentRepo);
+      if (data !== null) {
+        setDeveloperNetwork(data);
+      } else {
+        setStatusCode(404);
       }
     })();
   }, [developerPeriod]);

--- a/src/views/RepoActORTrendView/RepoActORTrendView.tsx
+++ b/src/views/RepoActORTrendView/RepoActORTrendView.tsx
@@ -40,12 +40,8 @@ const RepoActORTrendView: React.FC<RepoActORTrendViewProps> = ({
 
   useEffect(() => {
     (async () => {
-      try {
-        setActivity(await getActivity(currentRepo));
-        setOpenrank(await getOpenrank(currentRepo));
-      } catch (e) {
-        console.error(e);
-      }
+      setActivity(await getActivity(currentRepo));
+      setOpenrank(await getOpenrank(currentRepo));
     })();
   }, []);
 

--- a/src/views/RepoDetailForkView/RepoDetailForkView.tsx
+++ b/src/views/RepoDetailForkView/RepoDetailForkView.tsx
@@ -33,11 +33,7 @@ const RepoDetailForkView: React.FC<RepoDetailForkViewProps> = ({
 
   useEffect(() => {
     (async () => {
-      try {
-        setForks(await getForks(currentRepo));
-      } catch (e) {
-        console.error(e);
-      }
+      setForks(await getForks(currentRepo));
     })();
   }, []);
 

--- a/src/views/RepoDetailIssueView/IssueChart.tsx
+++ b/src/views/RepoDetailIssueView/IssueChart.tsx
@@ -38,6 +38,11 @@ const IssueChart: React.FC<IssueChartProps> = (props) => {
       textStyle: {
         color: TH.FG_COLOR,
       },
+      selected: {
+        open: data.issuesOpened.length > 0,
+        close: data.issuesClosed.length > 0,
+        comment: data.issueComments.length > 0,
+      },
     },
     tooltip: {
       trigger: 'axis',

--- a/src/views/RepoDetailIssueView/RepoDetailIssueView.tsx
+++ b/src/views/RepoDetailIssueView/RepoDetailIssueView.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 
-import { getGithubTheme, getMessageByLocale } from '../../utils/utils';
+import {
+  getGithubTheme,
+  getMessageByLocale,
+  isNull,
+  isAllNull,
+} from '../../utils/utils';
 import Settings, { loadSettings } from '../../utils/settings';
 import { generateDataByMonth } from '../../utils/data';
 import {
@@ -45,19 +50,15 @@ const RepoDetailIssueView: React.FC<RepoDetailIssueViewProps> = ({
 
   useEffect(() => {
     (async () => {
-      try {
-        setIssue({
-          issuesOpened: await getIssuesOpened(currentRepo),
-          issuesClosed: await getIssuesClosed(currentRepo),
-          issueComments: await getIssueComments(currentRepo),
-        });
-      } catch (e) {
-        console.error(e);
-      }
+      setIssue({
+        issuesOpened: await getIssuesOpened(currentRepo),
+        issuesClosed: await getIssuesClosed(currentRepo),
+        issueComments: await getIssueComments(currentRepo),
+      });
     })();
   }, []);
 
-  if (!issue) return null;
+  if (isNull(issue) || isAllNull(issue)) return null;
 
   const onClick = (curMonth: string, params: any) => {
     const seriesIndex = params.seriesIndex;

--- a/src/views/RepoDetailPRView/MergedLinesChart.tsx
+++ b/src/views/RepoDetailPRView/MergedLinesChart.tsx
@@ -37,6 +37,10 @@ const MergedLinesChart: React.FC<MergedLinesChartProps> = (props) => {
       textStyle: {
         color: TH.FG_COLOR,
       },
+      selected: {
+        addition: data.mergedCodeAddition.length > 0,
+        deletion: data.mergedCodeDeletion.length > 0,
+      },
     },
     tooltip: {
       trigger: 'axis',

--- a/src/views/RepoDetailPRView/PRChart.tsx
+++ b/src/views/RepoDetailPRView/PRChart.tsx
@@ -38,6 +38,11 @@ const PRChart: React.FC<PRChartProps> = (props) => {
       textStyle: {
         color: TH.FG_COLOR,
       },
+      selected: {
+        open: data.PROpened.length > 0,
+        merge: data.PRMerged.length > 0,
+        review: data.PRReviews.length > 0,
+      },
     },
     tooltip: {
       trigger: 'axis',

--- a/src/views/RepoDetailPRView/RepoDetailPRView.tsx
+++ b/src/views/RepoDetailPRView/RepoDetailPRView.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 
-import { getGithubTheme, getMessageByLocale } from '../../utils/utils';
+import {
+  getGithubTheme,
+  getMessageByLocale,
+  isNull,
+  isAllNull,
+} from '../../utils/utils';
 import Settings, { loadSettings } from '../../utils/settings';
 import { generateDataByMonth } from '../../utils/data';
 import {
@@ -59,21 +64,17 @@ const RepoDetailPRView: React.FC<RepoDetailPRViewProps> = ({ currentRepo }) => {
 
   useEffect(() => {
     (async () => {
-      try {
-        setPR({
-          PROpened: await getPROpened(currentRepo),
-          PRMerged: await getPRMerged(currentRepo),
-          PRReviews: await getPRReviews(currentRepo),
-          mergedCodeAddition: await getMergedCodeAddition(currentRepo),
-          mergedCodeDeletion: await getMergedCodeDeletion(currentRepo),
-        });
-      } catch (e) {
-        console.error(e);
-      }
+      setPR({
+        PROpened: await getPROpened(currentRepo),
+        PRMerged: await getPRMerged(currentRepo),
+        PRReviews: await getPRReviews(currentRepo),
+        mergedCodeAddition: await getMergedCodeAddition(currentRepo),
+        mergedCodeDeletion: await getMergedCodeDeletion(currentRepo),
+      });
     })();
   }, []);
 
-  if (!PR) return null;
+  if (isNull(PR) || isAllNull(PR)) return null;
 
   const onClick = (curMonth: string, params: any) => {
     const seriesIndex = params.seriesIndex;

--- a/src/views/RepoDetailStarView/RepoDetailStarView.tsx
+++ b/src/views/RepoDetailStarView/RepoDetailStarView.tsx
@@ -33,11 +33,7 @@ const RepoDetailStarView: React.FC<RepoDetailStarViewProps> = ({
 
   useEffect(() => {
     (async () => {
-      try {
-        setStars(await getStars(currentRepo));
-      } catch (e) {
-        console.error(e);
-      }
+      setStars(await getStars(currentRepo));
     })();
   }, []);
 

--- a/src/views/RepoHeaderLabelsView/RepoHeaderLabelsView.tsx
+++ b/src/views/RepoHeaderLabelsView/RepoHeaderLabelsView.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 
-import { getGithubTheme, getMessageByLocale } from '../../utils/utils';
+import {
+  getGithubTheme,
+  getMessageByLocale,
+  isNull,
+  isAllNull,
+} from '../../utils/utils';
 import { numberWithCommas } from '../../utils/formatter';
 import Settings, { loadSettings } from '../../utils/settings';
 import { getActivity, getOpenrank, getParticipant } from '../../api/repo';
@@ -37,19 +42,15 @@ const RepoHeaderLabelsView: React.FC<RepoHeaderLabelsViewProps> = ({
 
   useEffect(() => {
     (async () => {
-      try {
-        setData({
-          activity: await getActivity(currentRepo),
-          OpenRank: await getOpenrank(currentRepo),
-          participant: await getParticipant(currentRepo),
-        });
-      } catch (e) {
-        console.error(e);
-      }
+      setData({
+        activity: await getActivity(currentRepo),
+        OpenRank: await getOpenrank(currentRepo),
+        participant: await getParticipant(currentRepo),
+      });
     })();
   }, []);
 
-  if (!data) return null;
+  if (isNull(data) || isAllNull(data)) return null;
 
   const activityData = generateDataByMonth(data.activity);
   const OpenRankData = generateDataByMonth(data.OpenRank);


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [x] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #564

## Details
<!-- What did you do in this PR?  -->
The reason why one missing metric file fails the whole PR chart is because we regarded metric files consumed by the PR chart as a whole. In another word, only all data files are ready do the PR chart will show itself in that way.

In this PR, I modified code so a PR chart with some metric missing is allowed:

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/32434520/215700585-97d0b0b5-45e1-4b95-90d5-99ae5c9402c8.png">

And I also made some changes in error handling.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
