### PR TITLE
fix: early load of repo-activity-openrank-trands results in wrong width when network is bad

### DIFF
--- a/src/pages/ContentScripts/features/repo-activity-openrank-trends/index.tsx
+++ b/src/pages/ContentScripts/features/repo-activity-openrank-trends/index.tsx
@@ -42,15 +42,6 @@ const init = async (): Promise<void> => {
   newBorderGridCell.className = 'BorderGrid-cell';
   newBorderGridRow.appendChild(newBorderGridCell);
 
-  /**
-   * `awaitDomReady` is set to `false` below, which means the `init()` of this feature
-   * will run as early as possible without waiting for the whole DOM ready. So the time
-   * saved can be used to fetch data and create elements and etc. However, certain DOM
-   * nodes should still be waited because before injecting features(elements) into pages
-   * those related DOM nodes must exist. Otherwise there would be no place to inject the
-   * feature then errors would occur.
-   */
-  await elementReady('div.Layout-sidebar');
   renderTo(newBorderGridCell);
 
   const borderGridRows = $('div.Layout-sidebar').children('.BorderGrid');
@@ -69,7 +60,7 @@ const restore = async () => {
 
 features.add(featureId, {
   include: [pageDetect.isRepoHome],
-  awaitDomReady: false,
+  awaitDomReady: true,
   init,
   restore,
 });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- No related issue. This is a fix to https://github.com/hypertrons/hypertrons-crx/pull/548/commits/83523fde5b130152e7d724840c6427f92fe5a8d9

## Details
<!-- What did you do in this PR?  -->
<img width="1698" alt="image" src="https://user-images.githubusercontent.com/32434520/217250136-7aa25e9f-4fc5-4ab9-a102-eb718c7726ad.png">

The problem shown in the picture only reveals itself when users are in a bad network and they visit the GitHub sites without any cache. In that situation, the browser spends a lot of time to fetch all resources and load them one by one, however the feature is configured to not wait allDomReady but run itself as soon as `div.Layout-sidebar` is ready, which 
 works well in normal situations but unfortunately doesn't work in this one.

I tried hard for several hours to find out an earliest and correct point to load the feature but failed. The black box I was facing is hard to guess. Finally I gave in and raised this PR, where I did:

- set `awaitDomReady` to `true` so the feature will run itself after all dom elements are ready (just same as the strategy used in versions before v2.0.0) 

Hope this problem can be solved in a better way some day.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
