### PR TITLE
fix: some charts are broken because of new data fields like `yyyy-mm-raw`

### DIFF
--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -2,7 +2,17 @@ export const generateDataByMonth = (originalData: any) => {
   if (originalData === null) {
     return [];
   }
-  const orderedMonths = Object.keys(originalData).sort((a, b) => {
+
+  const isNormalMonth = (key: string): boolean => {
+    return key.match(/^\d{4}-\d{2}$/) !== null;
+  };
+  // `originalData` is an object with keys like `2020-01`, `2020-02`, `2022`, `2022-Q1`, `all`.
+  // A normal month is a key like `2020-01`(yyyy-mm). They are the keys we handle later in this function.
+  // An unnormal month is a key like `2020`, `2020-Q1`, `all`. They are not used in any feature yet.
+  const normalMonths = Object.keys(originalData).filter((key) =>
+    isNormalMonth(key)
+  );
+  const orderedMonths = normalMonths.sort((a, b) => {
     const dateA = new Date(a);
     const dateB = new Date(b);
     if (dateA < dateB) return -1;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #583 
- resolve #577

## Details
<!-- What did you do in this PR?  -->
> `originalData` is an object with keys like `2020-01`, `2020-02`, `2022`, `2022-Q1`, `all`.
> A normal month is a key like `2020-01`(yyyy-mm). They are the keys we handle later in this function.
> An unnormal month is a key like `2020`, `2020-Q1`, `all`. They are not used in any feature yet.

In this PR, I just filtered out those unnormal months at the beginning of the function. They will be used in future when we develop features consuming unnormal months.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
None.