### PR TITLE
fix: false positve case of isPerceptor

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -61,7 +61,7 @@ export function getMessageI18n(key: string) {
 }
 
 export const isPerceptor = (): boolean =>
-  window.location.search.includes('perceptor');
+  window.location.search.includes('?redirect=perceptor');
 
 export const compareVersion = (version_1: string, version_2: string) => {
   const v1 = version_1.split('.');


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #603 

## Details
<!-- What did you do in this PR?  -->
Since most of the search content will be translated to special symbols in the URL , for example ```=``` will be converted to ```%3```. So here the problem can be solved by replacing ```perceptor``` with ```?redirect=perceptor ```.
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
