### PR TITLE
fix: the network will crash if no edge provided

### DIFF
--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -42,6 +42,9 @@ const generateEchartsData = (
     });
   };
   const generateEdges = (edges: any[]): any => {
+    if (edges.length === 0) {
+      return [];
+    }
     const threshold = edges[0][0].split('/').length === 2 ? 5 : 2.5;
     return edges
       .map((e: any) => {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #593 

## Details
<!-- What did you do in this PR?  -->
Added the judgment of whether ths edges is empty.
Now network chart  works  well  when edges are empty.

![image](https://user-images.githubusercontent.com/62098023/225002787-befe9aca-a7cc-471a-bcb1-64500f7d8d8f.png)




## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
