### PR TITLE
feat: enable emoji picker in OSS-GPT chat widget

### DIFF
--- a/src/anchors/DocsGPTChatWidget.tsx
+++ b/src/anchors/DocsGPTChatWidget.tsx
@@ -67,10 +67,10 @@ class DocsGPTChatWidgetAnchor extends PerceptorBase {
 
     const container = document.createElement('div');
     container.id = 'docs-gpt-chat-widget';
-    container.className = getGithubTheme()!;
     container.dataset.repo = this._currentRepo; // mark current repo by data-repo
     render(
       <DocsGPTChatWidget
+        theme={getGithubTheme() as 'light' | 'dark'}
         currentRepo={this._currentRepo}
         currentDocsName={this._currentDocsName}
       />,

--- a/src/views/DocsGPTChatWidget/index.tsx
+++ b/src/views/DocsGPTChatWidget/index.tsx
@@ -6,11 +6,13 @@ import {
   toggleMsgLoader,
   toggleInputDisabled,
 } from 'react-chat-widget';
+import $ from 'jquery';
 
 import { getAnswer } from './service';
 import './rcw.scss';
 
 interface Props {
+  theme: 'light' | 'dark';
   currentRepo: string;
   currentDocsName: string | null;
 }
@@ -27,7 +29,7 @@ const displayNotAvailable = (repoName: string) => {
   );
 };
 
-const View = ({ currentRepo, currentDocsName }: Props): JSX.Element => {
+const View = ({ theme, currentRepo, currentDocsName }: Props): JSX.Element => {
   const subtitle = currentDocsName
     ? `Ask anything about ${currentRepo}`
     : `NOT AVAILABLE for ${currentRepo}`;
@@ -61,17 +63,41 @@ const View = ({ currentRepo, currentDocsName }: Props): JSX.Element => {
       displayNotAvailable(currentRepo);
     }
   }, [currentRepo, currentDocsName]);
+  useEffect(() => {
+    // Select the node that will be observed for mutations
+    const targetNode = $('div.rcw-widget-container')[0]!;
+    // Options for the observer (which mutations to observe)
+    const config = { attributes: true, childList: true, subtree: true };
+    // Callback function to execute when mutations are observed
+    const callback: MutationCallback = (mutationList, observer) => {
+      if ($('section.emoji-mart').length > 0) {
+        $('section.emoji-mart')
+          .removeClass('emoji-mart-light')
+          .addClass(`emoji-mart-${theme}`);
+      }
+    };
+    // Create an observer instance linked to the callback function
+    const observer = new MutationObserver(callback);
+    // Start observing the target node for configured mutations
+    observer.observe(targetNode, config);
 
+    return () => {
+      // Later, you can stop observing
+      observer.disconnect();
+    };
+  }, []);
   return (
-    <Widget
-      title="OSS-GPT"
-      subtitle={subtitle}
-      emojis={false} // will be enabled after style is fine tuned for two themes
-      resizable={true}
-      handleNewUserMessage={handleNewUserMessage}
-      showBadge={false}
-      profileAvatar={chrome.runtime.getURL('main.png')}
-    />
+    <div className={theme}>
+      <Widget
+        title="OSS-GPT"
+        subtitle={subtitle}
+        emojis={true} // will be enabled after style is fine tuned for two themes
+        resizable={true}
+        handleNewUserMessage={handleNewUserMessage}
+        showBadge={false}
+        profileAvatar={chrome.runtime.getURL('main.png')}
+      />
+    </div>
   );
 };
 

--- a/src/views/DocsGPTChatWidget/index.tsx
+++ b/src/views/DocsGPTChatWidget/index.tsx
@@ -69,22 +69,25 @@ const View = ({ theme, currentRepo, currentDocsName }: Props): JSX.Element => {
     // Options for the observer (which mutations to observe)
     const config = { attributes: true, childList: true, subtree: true };
     // Callback function to execute when mutations are observed
-    const callback: MutationCallback = (mutationList, observer) => {
-      if ($('section.emoji-mart').length > 0) {
-        $('section.emoji-mart')
-          .removeClass('emoji-mart-light')
-          .addClass(`emoji-mart-${theme}`);
-      }
-    };
-    // Create an observer instance linked to the callback function
-    const observer = new MutationObserver(callback);
-    // Start observing the target node for configured mutations
-    observer.observe(targetNode, config);
+    if (theme == 'dark') {
+      const callback: MutationCallback = (mutationList, observer) => {
+        if ($('section.emoji-mart').length > 0) {
+          $('section.emoji-mart')
+            .removeClass('emoji-mart-light')
+            .addClass(`emoji-mart-${theme}`);
+        }
+      };
 
-    return () => {
-      // Later, you can stop observing
-      observer.disconnect();
-    };
+      // Create an observer instance linked to the callback function
+      const observer = new MutationObserver(callback);
+      // Start observing the target node for configured mutations
+      observer.observe(targetNode, config);
+
+      return () => {
+        // Later, you can stop observing
+        observer.disconnect();
+      };
+    }
   }, []);
   return (
     <div className={theme}>

--- a/src/views/DocsGPTChatWidget/rcw.scss
+++ b/src/views/DocsGPTChatWidget/rcw.scss
@@ -221,8 +221,8 @@
 }
 .rcw-messages-container {
   background-color: var(--color-canvas-default);
-  height: 50vh;
-  max-height: 410px;
+  height: 55vh;
+  max-height: 600px;
   overflow-y: auto;
   padding-top: 10px;
   -webkit-overflow-scrolling: touch;
@@ -423,6 +423,7 @@ img.rcw-picker-icon {
 }
 .emoji-mart-search {
   margin-top: 6px;
+  margin-bottom: 6px;
   padding: 0 6px;
   position: relative;
 }
@@ -444,7 +445,7 @@ img.rcw-picker-icon {
 }
 .emoji-mart-search-icon {
   position: absolute;
-  top: 7px;
+  top: 5px;
   right: 11px;
   z-index: 2;
   padding: 2px 5px 1px;
@@ -731,7 +732,7 @@ img.rcw-picker-icon {
 }
 .emoji-mart-dark {
   color: #fff;
-  background-color: #222;
+  background-color: #161b22;
 }
 .emoji-mart-dark,
 .emoji-mart-dark .emoji-mart-bar {
@@ -740,7 +741,7 @@ img.rcw-picker-icon {
 .emoji-mart-dark .emoji-mart-search input {
   color: #fff;
   border-color: #555453;
-  background-color: #2f2f2f;
+  background-color: #161b22;
 }
 .emoji-mart-dark .emoji-mart-search-icon svg {
   fill: #fff;
@@ -749,7 +750,7 @@ img.rcw-picker-icon {
   background-color: #444;
 }
 .emoji-mart-dark .emoji-mart-category-label span {
-  background-color: #222;
+  background-color: #161b22;
   color: #fff;
 }
 .emoji-mart-dark .emoji-mart-skin-swatches {

--- a/src/views/DocsGPTChatWidget/rcw.scss
+++ b/src/views/DocsGPTChatWidget/rcw.scss
@@ -30,7 +30,7 @@
 .rcw-client .rcw-message-text {
   background-color: var(--color-accent-subtle);
   border-radius: 10px;
-  max-width: 215px;
+  max-width: 350px;
   padding: 15px;
   text-align: left;
   white-space: pre-wrap;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- feature #613 

## Details
<!-- What did you do in this PR?  -->
- Enable the emoji panel in rcw.
- The style of the emoji picker should be fine tuned for both themes.
- Adjusting the length of rcw and the width of the user chat box
### Example：
- Light theme：

![light](https://user-images.githubusercontent.com/50283262/225629274-91f2b34d-27d5-4f9c-b6e0-25f03c9f8371.png)

- Dark theme：

![dark](https://user-images.githubusercontent.com/50283262/225625002-9b383218-56dc-47eb-a9e0-02f8a182c583.png)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
