### PR TITLE
feat: Increase the trigger time threshold for issue, pull request, fork and star charts

### DIFF
--- a/src/anchors/RepoDetailForkAnchor.tsx
+++ b/src/anchors/RepoDetailForkAnchor.tsx
@@ -37,7 +37,7 @@ class RepoDetailForkAnchor extends PerceptorBase {
       'data-place': 'bottom',
       'data-effect': 'solid',
       'data-delay-hide': 500,
-      'data-delay-show': 500,
+      'data-delay-show': 1000,
       style: { color: githubTheme === 'light' ? '#24292f' : '#c9d1d9' },
       'data-text-color': githubTheme === 'light' ? '#24292F' : '#C9D1D9',
       'data-background-color': githubTheme === 'light' ? 'white' : '#161B22',

--- a/src/anchors/RepoDetailIssueAnchor.tsx
+++ b/src/anchors/RepoDetailIssueAnchor.tsx
@@ -37,7 +37,7 @@ class RepoDetailIssueAnchor extends PerceptorBase {
       'data-place': 'bottom',
       'data-effect': 'solid',
       'data-delay-hide': 500,
-      'data-delay-show': 500,
+      'data-delay-show': 1000,
       style: { color: githubTheme === 'light' ? '#24292f' : '#c9d1d9' },
       'data-text-color': githubTheme === 'light' ? '#24292F' : '#C9D1D9',
       'data-background-color': githubTheme === 'light' ? 'white' : '#161B22',
@@ -47,7 +47,7 @@ class RepoDetailIssueAnchor extends PerceptorBase {
     tooltipContainer.id = 'issue-tooltip-container';
     $('#repository-container-header').append(tooltipContainer);
     render(
-      <RepoDetailIssueView currentRepo={this._currentRepo} />,
+      <RepoDetailIssueView currentRepo={this._currentRepo}/>,
       tooltipContainer
     );
   }

--- a/src/anchors/RepoDetailPRAnchor.tsx
+++ b/src/anchors/RepoDetailPRAnchor.tsx
@@ -37,7 +37,7 @@ class RepoDetailPRAnchor extends PerceptorBase {
       'data-place': 'bottom',
       'data-effect': 'solid',
       'data-delay-hide': 500,
-      'data-delay-show': 500,
+      'data-delay-show': 1000,
       style: { color: githubTheme === 'light' ? '#24292f' : '#c9d1d9' },
       'data-text-color': githubTheme === 'light' ? '#24292F' : '#C9D1D9',
       'data-background-color': githubTheme === 'light' ? 'white' : '#161B22',

--- a/src/anchors/RepoDetailStarAnchor.tsx
+++ b/src/anchors/RepoDetailStarAnchor.tsx
@@ -37,7 +37,7 @@ class RepoDetailStarAnchor extends PerceptorBase {
       'data-place': 'left',
       'data-effect': 'solid',
       'data-delay-hide': 500,
-      'data-delay-show': 500,
+      'data-delay-show': 1000,
       style: { color: githubTheme === 'light' ? '#24292f' : '#c9d1d9' },
       'data-text-color': githubTheme === 'light' ? '#24292F' : '#C9D1D9',
       'data-background-color': githubTheme === 'light' ? 'white' : '#161B22',


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- keyword #628 

## Details
As the related issue mentioned, some charts appear too early after the mouse hover. I Increased the rigger time treshold for four charts that may cause the problems mentioned in the related issue. The four charts are respectively issue, pull request, fork and star charts. I changed the appearance time from 500ms after hover to 1000ms. 


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
N.A.
