### PR TITLE
fix: wrongly highlight tab

### DIFF
--- a/src/pages/ContentScripts/features/perceptor-tab/index.tsx
+++ b/src/pages/ContentScripts/features/perceptor-tab/index.tsx
@@ -20,6 +20,8 @@ const addPerceptorTab = async (): Promise<void | false> => {
   }
   const perceptorTab = insightsTab.cloneNode(true) as HTMLAnchorElement;
   delete perceptorTab.dataset.selectedLinks;
+  perceptorTab.removeAttribute('aria-current')
+  perceptorTab.classList.remove('selected');
   const perceptorHref = `${insightsTab.href}?redirect=perceptor`;
   perceptorTab.href = perceptorHref;
   perceptorTab.id = featureId;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- close #636 

## Details
<!-- What did you do in this PR?  -->
Remove the highlight class and attribute of perceptor tab after copying from insight tab

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
