### PR TITLE
fix: add repo-header-labels repeatedly

### DIFF
--- a/src/pages/ContentScripts/features/repo-header-labels/index.tsx
+++ b/src/pages/ContentScripts/features/repo-header-labels/index.tsx
@@ -36,6 +36,9 @@ const init = async (): Promise<void> => {
   container.id = featureId;
   renderTo(container);
   await elementReady('#repository-container-header');
+
+  if ($('#hypercrx-repo-header-labels').length > 0) return;
+
   $('#repository-container-header')
     .find('span.Label.Label--secondary')
     .after(container);


### PR DESCRIPTION
## Brief Information

When a new issue is created from the created issue page and the repository does not have a configuration template, multiple header-label are added to the form page.

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- keyword #xxx

## Details
<!-- What did you do in this PR?  -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->

fix: #686