### PR TITLE
fix: repositioning the fork chart

### DIFF
--- a/src/pages/ContentScripts/features/repo-fork-tooltip/index.tsx
+++ b/src/pages/ContentScripts/features/repo-fork-tooltip/index.tsx
@@ -32,7 +32,7 @@ const init = async (): Promise<void> => {
     'data-tip': '',
     'data-for': 'fork-tooltip',
     'data-class': `floating-window ${githubTheme}`,
-    'data-place': 'bottom',
+    'data-place': 'left',
     'data-effect': 'solid',
     'data-delay-hide': 500,
     'data-delay-show': 1000,


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues:

-  fix #663 

## Details
Relocating the chart to the left side of the fork button. Now, default popup will occupy minimal space, and the chart's title is clearly visible. 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
N.A.