### PR TITLE
fix: truncate redundant profile information

### DIFF
--- a/src/helpers/get-developer-info.ts
+++ b/src/helpers/get-developer-info.ts
@@ -1,5 +1,5 @@
 import $ from 'jquery';
 
 export function getDeveloperName() {
-  return $('.p-nickname.vcard-username.d-block').text().trim();
+  return $('.p-nickname.vcard-username.d-block').text().trim().split(' ')[0];
 }


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- resolve #684 

## Details
<!-- What did you do in this PR?  -->
- The problem is that when requesting data after setting additional personal information, wrong parameters will be passed in, as shown in the circle on the console on the right side of the figure below:

![image](https://github.com/hypertrons/hypertrons-crx/assets/50283262/51ffef55-5942-4510-8440-25ee7fdd8ea7)

- In the code, additionally use the `split` method to intercept the string before the space to solve this problem.
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
