### PR TITLE
 chore: escape checkbox in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,14 @@
 
 This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):
 
-- [ ] build
-- [ ] ci
-- [ ] docs
-- [ ] feat
-- [ ] fix
-- [ ] perf
-- [ ] refactor
-- [ ] test
+- `[ ]` build
+- `[ ]` ci
+- `[ ]` docs
+- `[ ]` feat
+- `[ ]` fix
+- `[ ]` perf
+- `[ ]` refactor
+- `[ ]` test
 
 Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):
 
@@ -20,8 +20,8 @@ Related issues ([all available keywords](https://docs.github.com/en/issues/track
 
 ## Checklist
 
-- [ ] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
-- [ ] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)
+- `[ ]` I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
+- `[ ]` I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)
 
 ## Others
 <!-- Other information you want to share.  -->


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- `[ ]` build
- `[ ]` ci
- `[x]` docs
- `[ ]` feat
- `[ ]` fix
- `[ ]` perf
- `[ ]` refactor
- `[ ]` test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- #734

## Details
<!-- What did you do in this PR?  -->

Just avoid GitHub PR regex on the checkbox in the most straightforward way.

## Checklist

- `[x]` I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- `[x]` I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
N.A.