### PR TITLE
fix: duplicate numbers on repo-activity-racing-bar

### DIFF
--- a/src/pages/ContentScripts/features/repo-activity-racing-bar/data.ts
+++ b/src/pages/ContentScripts/features/repo-activity-racing-bar/data.ts
@@ -13,6 +13,25 @@ export interface RepoActivityDetails {
 }
 
 /**
+ * Filter and extract monthly data from the given data structure, which includes various date formats such as "yyyy", "yyyy-Qq", and "yyyy-mm".
+ * This function extracts and returns only the monthly data in the "yyyy-mm" format.
+ *
+ * @param data: RepoActivityDetails
+ * @returns RepoActivityDetails
+ */
+export function getMonthlyData(data: RepoActivityDetails) {
+  const monthlyData: RepoActivityDetails = {};
+
+  for (const key in data) {
+    // Check if the key matches the yyyy-mm format (e.g., "2020-05")
+    if (/^\d{4}-\d{2}$/.test(key)) {
+      monthlyData[key] = data[key];
+    }
+  }
+  return monthlyData;
+}
+
+/**
  * Count the number of unique contributors in the data
  * @returns [number of long term contributors, contributors' names]
  */

--- a/src/pages/ContentScripts/features/repo-activity-racing-bar/view.tsx
+++ b/src/pages/ContentScripts/features/repo-activity-racing-bar/view.tsx
@@ -4,7 +4,7 @@ import optionsStorage, {
   defaults,
 } from '../../../../options-storage';
 import RacingBar, { MediaControlers } from './RacingBar';
-import { RepoActivityDetails } from './data';
+import { RepoActivityDetails, getMonthlyData } from './data';
 import { PlayerButton } from './PlayerButton';
 import { SpeedController } from './SpeedController';
 
@@ -91,7 +91,7 @@ const View = ({ currentRepo, repoActivityDetails }: Props): JSX.Element => {
               <RacingBar
                 ref={mediaControlersRef}
                 speed={speed}
-                data={repoActivityDetails}
+                data={getMonthlyData(repoActivityDetails)}
                 setPlaying={setPlaying}
               />
             </div>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- resolve #750 

## Details
1. Add a function `getMonthlyData` to extract only the monthly data.
2. Use the above function to filter monthly data from `repoActivityDetails`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
