### PR TITLE
chore: add message prompt that GPT conversation backend is deprecated

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -339,6 +339,6 @@
     "message": "OSS-GPT currently is **NOT AVAILABLE** for %v. If you want docs support for the repository, please check [this issue](https://github.com/hypertrons/hypertrons-crx/issues/609) and make a request there :)\n\nSee [all available docs](https://oss.x-lab.info/hypercrx/docsgpt_active_docs.json)\n\nThis chat widget can also be enabled/disabled in the extension options page whenever you want."
   },
   "OSS_GPT_errorMessage": {
-    "message": "Sorry, due to cost reasons, the OSS-GPT function is currently out of use. Please follow [HyperCRX](https://github.com/hypertrons/hypertrons-crx) for the latest news."
+    "message": "Sorry, due to cost reasons, the OSS-GPT function is currently not available. Please follow [HyperCRX](https://github.com/hypertrons/hypertrons-crx) for the latest news."
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -337,5 +337,8 @@
   },
   "OSS_GPT_notAvailable": {
     "message": "OSS-GPT currently is **NOT AVAILABLE** for %v. If you want docs support for the repository, please check [this issue](https://github.com/hypertrons/hypertrons-crx/issues/609) and make a request there :)\n\nSee [all available docs](https://oss.x-lab.info/hypercrx/docsgpt_active_docs.json)\n\nThis chat widget can also be enabled/disabled in the extension options page whenever you want."
+  },
+  "OSS_GPT_errorMessage": {
+    "message": "Sorry, due to cost reasons, the OSS-GPT function is currently out of use. Please follow [HyperCRX](https://github.com/hypertrons/hypertrons-crx) for the latest news."
   }
 }

--- a/src/locales/zh_CN/messages.json
+++ b/src/locales/zh_CN/messages.json
@@ -339,6 +339,6 @@
     "message": "OSS-GPT 暂未支持 %v。如果您想使此仓库得到文档问答支持，请前往[该 issue](https://github.com/hypertrons/hypertrons-crx/issues/609) 提交需求 :)\n\n查看[所有已支持文档](https://oss.x-lab.info/hypercrx/docsgpt_active_docs.json)\n\n您也可以随时在扩展选项页面中启用/禁用此聊天小部件。"
   },
   "OSS_GPT_errorMessage": {
-    "message": "很抱歉，由于成本原因，目前 OSS-GPT 功能处于停止使用的状态。请关注 [HyperCRX](https://github.com/hypertrons/hypertrons-crx) 获取最新消息。"
+    "message": "很抱歉，由于成本原因，目前 OSS-GPT 功能处于停用状态。请关注 [HyperCRX](https://github.com/hypertrons/hypertrons-crx) 获取最新消息。"
   }
 }

--- a/src/locales/zh_CN/messages.json
+++ b/src/locales/zh_CN/messages.json
@@ -337,5 +337,8 @@
   },
   "OSS_GPT_notAvailable": {
     "message": "OSS-GPT 暂未支持 %v。如果您想使此仓库得到文档问答支持，请前往[该 issue](https://github.com/hypertrons/hypertrons-crx/issues/609) 提交需求 :)\n\n查看[所有已支持文档](https://oss.x-lab.info/hypercrx/docsgpt_active_docs.json)\n\n您也可以随时在扩展选项页面中启用/禁用此聊天小部件。"
+  },
+  "OSS_GPT_errorMessage": {
+    "message": "很抱歉，由于成本原因，目前 OSS-GPT 功能处于停止使用的状态。请关注 [HyperCRX](https://github.com/hypertrons/hypertrons-crx) 获取最新消息。"
   }
 }

--- a/src/pages/ContentScripts/features/oss-gpt/service.ts
+++ b/src/pages/ContentScripts/features/oss-gpt/service.ts
@@ -5,26 +5,31 @@ export const getAnswer = async (
   question: string,
   history: [string, string]
 ) => {
-  const response = await fetch(`${DOCS_GPT_ENDPOINT}/answer`, {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      active_docs: activeDocs,
-      api_key: null,
-      embeddings_key: null,
-      history: JSON.stringify(history),
-      question,
-    }),
-    mode: 'cors',
-  });
-  if (!response.ok) {
-    return 'Oops, something went wrong.';
-  } else {
-    const data = await response.json();
-    const anwser = data.answer;
-    return anwser;
+  try {
+    const response = await fetch(`${DOCS_GPT_ENDPOINT}/answer`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        active_docs: activeDocs,
+        api_key: null,
+        embeddings_key: null,
+        history: JSON.stringify(history),
+        question,
+      }),
+      mode: 'cors',
+    });
+    if (!response.ok) {
+      return 'Oops, something went wrong.';
+    } else {
+      const data = await response.json();
+      const answer = data.answer;
+      return answer;
+    }
+  } catch (error) {
+    console.error('Error:', error);
+    return 'error';
   }
 };

--- a/src/pages/ContentScripts/features/oss-gpt/view.tsx
+++ b/src/pages/ContentScripts/features/oss-gpt/view.tsx
@@ -35,6 +35,11 @@ const displayNotAvailable = (repoName: string, locale: string) => {
   );
 };
 
+// Due to cost reasons, backend is not available now. This part can be removed when the backend is restored.
+const backendNotAvailable = (locale: string) => {
+  addResponseMessage(getMessageByLocale('OSS_GPT_errorMessage', locale));
+};
+
 const View = ({ theme, currentRepo, currentDocsName }: Props): JSX.Element => {
   const [options, setOptions] = useState<HypercrxOptions>(defaults);
   const [history, setHistory] = useState<[string, string]>(['', '']);
@@ -132,8 +137,12 @@ const View = ({ theme, currentRepo, currentDocsName }: Props): JSX.Element => {
 
     if (currentDocsName) {
       const answer = await getAnswer(currentDocsName, newMessage, history);
-      addResponseMessage(answer);
-      setHistory([newMessage, answer]); // update history
+      if (answer == 'error') {
+        backendNotAvailable(options.locale);
+      } else {
+        addResponseMessage(answer);
+        setHistory([newMessage, answer]); // update history
+      }
     } else {
       displayNotAvailable(currentRepo, options.locale);
     }


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- resolve #774

## Details
<!-- What did you do in this PR?  -->
**Since the backend service is deprecated, I added a message prompt that OSS-GPT is deprecated. As shown below:**

<img width="546" alt="image" src="https://github.com/hypertrons/hypertrons-crx/assets/50283262/6818aca7-a3b4-4fdf-9a70-05707145cc32">

**Correspondingly, there are also message in English:**

<img width="541" alt="image" src="https://github.com/hypertrons/hypertrons-crx/assets/50283262/af2b393f-27d7-4fb6-9d07-980d68425adb">

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
