### PR TITLE
fix: start chart not show when repo is unstarred

### DIFF
--- a/src/pages/ContentScripts/features/repo-star-tooltip/index.tsx
+++ b/src/pages/ContentScripts/features/repo-star-tooltip/index.tsx
@@ -33,7 +33,17 @@ const init = async (): Promise<void> => {
     ? 'button[data-ga-click*="star button"]'
     : 'a[data-hydro-click*="star button"]';
   await elementReady(starButtonSelector);
-  const $starButton = $(starButtonSelector);
+  // <div data-view-component="true" class="starred BtnGroup flex-1 ml-0">
+  // <div data-view-component="true" class="unstarred BtnGroup ml-0 flex-1">
+  // No matter the repo is starred or not, the two button are always there
+  // So we need to filter the visible one
+  const $starButton = $(starButtonSelector).filter(function () {
+    if ($(this).parent().parent().css('display') !== 'none') {
+      return true;
+    } else {
+      return false;
+    }
+  });
   const placeholderElement = $('<div class="NativePopover" />').appendTo(
     'body'
   )[0];


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #803

## Details
<!-- What did you do in this PR?  -->
<img width="1332" alt="image" src="https://github.com/hypertrons/hypertrons-crx/assets/32434520/e10deb4f-5846-41b2-9da8-2b5f210dc5b6">

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
