### PR TITLE
fix: native popover broken after tab switch

### DIFF
--- a/src/pages/ContentScripts/components/NativePopover.tsx
+++ b/src/pages/ContentScripts/components/NativePopover.tsx
@@ -76,6 +76,10 @@ export const NativePopover = ({
         leaveTimer = setTimeout(hidePopover, 200);
       });
 
+      anchor[0].addEventListener('click', () => {
+        hidePopover();
+      });
+
       $popoverContainer[0].addEventListener('mouseenter', () => {
         leaveTimer && clearTimeout(leaveTimer);
       });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- fix #817

## Details
<!-- What did you do in this PR?  -->
Add an click event listener for hiding the popover when the anchor element is clicked. In this way, the popover is cleared by a React method`unmountComponentAtNode` rather by the GitHub code.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
