### PR TITLE
fix: Contributors data is now displayed correctly

### DIFF
--- a/src/api/repo.ts
+++ b/src/api/repo.ts
@@ -5,7 +5,7 @@ const metricNameMap = new Map([
   ['activity', 'activity'],
   ['openrank', 'openrank'],
   ['participant', 'participants'],
-  ['contributor', 'new_contributors'],
+  ['contributor', 'contributors'],
   ['forks', 'technical_fork'],
   ['stars', 'stars'],
   ['issues_opened', 'issues_new'],


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- Fix #820 

## Details
<!-- What did you do in this PR?  -->
The contributors data will be correctly displayed as active contributors instead of new contributors
For example, the CONTRIBUTORS of the Redis project should be 4 instead of 0, and now it has been corrected。
![81ff2ad71ec2f30789e11871d9a3b5dd](https://github.com/hypertrons/hypertrons-crx/assets/68376741/33904e3f-426b-4167-bc14-caedbf426c91)


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
