### PR TITLE
fix: repo homepage latest commit hovercard openrank display

### DIFF
--- a/src/pages/ContentScripts/features/developer-hovercard-info/index.tsx
+++ b/src/pages/ContentScripts/features/developer-hovercard-info/index.tsx
@@ -83,7 +83,6 @@ const init = async (): Promise<void> => {
       popover?.setAttribute('data-popover-id', popoverId);
 
       const openrank = await getDeveloperLatestOpenrank(developerName);
-      console.log('openrank ' + openrank);
 
       if (!openrank) {
         return;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues #842 

- keyword #xxx

## Details
<!-- What did you do in this PR?  -->
![QQ_1721891276737](https://github.com/user-attachments/assets/5efc9324-d847-497f-8548-d27db6fc8a9c)


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
Thanks to Yantong's help, OpenRank can now be displayed normally in most scenarios.