### PR TITLE
fix: repo homepage latest commit hovercard openrank display

### DIFF
--- a/src/pages/ContentScripts/features/developer-hovercard-info/index.tsx
+++ b/src/pages/ContentScripts/features/developer-hovercard-info/index.tsx
@@ -31,11 +31,32 @@ const renderTo = (container: HTMLElement, developerName: string, openrank: strin
   ReactDOM.render(<View developerName={developerName} openrank={openrank} />, openRankContainer);
 };
 
+const elementReadyWithTimeout = async (selector: string, options: { stopOnDomReady: boolean }, timeout: number) => {
+  return Promise.race([
+    elementReady(selector, options),
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`Timeout waiting for ${selector}`)), timeout)),
+  ]);
+};
+
 const init = async (): Promise<void> => {
   let abortController = new AbortController();
-  const hovercardSelector = '[data-hovercard-type="user"]';
+  const hovercardSelector = '[data-hovercard-url]';
+
+  await elementReady(hovercardSelector, { stopOnDomReady: false });
+  // The loading time for the element with data-testid=github-avatar is 1500ms.
+  // If the timeout is not set, OpenRank will not be added normally.
+
+  try {
+    await elementReadyWithTimeout('[data-testid=github-avatar]', { stopOnDomReady: false }, 1500);
+  } catch (error) {
+    console.log('The current interface does not have data-testid=github-avatar information');
+  }
+
   document.querySelectorAll(hovercardSelector).forEach((element) => {
-    // isProcessing is used to Prevent OpenRank from adding duplicates
+    const hovercardUrl = element.getAttribute('data-hovercard-url');
+    if (!hovercardUrl || !hovercardUrl.startsWith('/users')) {
+      return;
+    }
     element.addEventListener('mouseover', async () => {
       abortController.abort();
       abortController = new AbortController();

--- a/src/pages/ContentScripts/features/developer-networks/react-modal.scss
+++ b/src/pages/ContentScripts/features/developer-networks/react-modal.scss
@@ -16,9 +16,7 @@
   transform: translate(-50%, -50%);
   padding: 24px;
   box-sizing: border-box;
-  box-shadow:
-    rgba(0, 0, 0, 0.22) 0px 25.6px 57.6px 0px,
-    rgba(0, 0, 0, 0.18) 0px 4.8px 14.4px 0px;
+  box-shadow: rgba(0, 0, 0, 0.22) 0px 25.6px 57.6px 0px, rgba(0, 0, 0, 0.18) 0px 4.8px 14.4px 0px;
   outline: transparent solid 3px;
   border-radius: 2px;
   background: var(--bgColor-default, var(--color-canvas-default));

--- a/src/pages/ContentScripts/features/oss-gpt/rcw.scss
+++ b/src/pages/ContentScripts/features/oss-gpt/rcw.scss
@@ -339,11 +339,7 @@ img.rcw-picker-icon {
   line-height: 1.15;
 }
 .emoji-mart {
-  font-family:
-    -apple-system,
-    BlinkMacSystemFont,
-    Helvetica Neue,
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, Helvetica Neue, sans-serif;
   font-size: 16px;
   display: inline-block;
   color: #222427;
@@ -509,13 +505,7 @@ img.rcw-picker-icon {
   box-shadow: none;
 }
 .emoji-mart-emoji-native {
-  font-family:
-    Segoe UI Emoji,
-    Segoe UI Symbol,
-    Segoe UI,
-    Apple Color Emoji,
-    Twemoji Mozilla,
-    Noto Color Emoji,
+  font-family: Segoe UI Emoji, Segoe UI Symbol, Segoe UI, Apple Color Emoji, Twemoji Mozilla, Noto Color Emoji,
     Android Emoji;
 }
 .emoji-mart-no-results {
@@ -781,18 +771,14 @@ img.rcw-picker-icon {
 .rcw-conversation-container.active {
   opacity: 1;
   transform: translateY(0);
-  transition:
-    opacity 0.3s ease,
-    transform 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 .rcw-conversation-container.hidden {
   z-index: -1;
   pointer-events: none;
   opacity: 0;
   transform: translateY(10px);
-  transition:
-    opacity 0.3s ease,
-    transform 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 .rcw-conversation-resizer {
   cursor: col-resize;

--- a/src/pages/Options/Options.css
+++ b/src/pages/Options/Options.css
@@ -4,9 +4,7 @@
   margin-top: 10px;
   opacity: 1;
   background: white;
-  box-shadow:
-    rgba(0, 0, 0, 0.14) 0px 2px 2px 0px,
-    rgba(0, 0, 0, 0.12) 0px 1px 5px 0px,
+  box-shadow: rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px,
     rgba(0, 0, 0, 0.2) 0px 3px 1px -2px;
   transition: all 0.2s ease 0s;
   border-radius: 3px;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related pr : #846 

- keyword #xxx

## Details
<!-- What did you do in this PR?  -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->

Still don't know why the hovercard functionality is sometimes introduced twice