### PR TITLE
fix: reserved digits for the length of the contributor bar 

### DIFF
--- a/src/pages/ContentScripts/features/repo-activity-racing-bar/data.ts
+++ b/src/pages/ContentScripts/features/repo-activity-racing-bar/data.ts
@@ -154,11 +154,13 @@ export const getOption = async (
         },
         label: {
           show: true,
-          precision: 1,
           position: 'right',
           valueAnimation: true,
           fontFamily: 'monospace',
           color: theme === 'light' ? undefined : DARK_TEXT_COLOR,
+          formatter: function (params: any) {
+            return params.data.value[1].toFixed(2);
+          },
         },
       },
     ],


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- keyword #853 

## Details
<!-- What did you do in this PR?  -->
![image](https://github.com/user-attachments/assets/f1195545-84bf-447a-b5bc-c5feb10885ca)
![image](https://github.com/user-attachments/assets/2195f6ac-110f-4f53-9012-87185fc48d6a)

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/9310ad4d-61d7-4aa6-86ba-9fd63575df0d">

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
