### PR TITLE
fix: repo star tooltip

### DIFF
--- a/src/pages/ContentScripts/features/repo-star-tooltip/index.tsx
+++ b/src/pages/ContentScripts/features/repo-star-tooltip/index.tsx
@@ -31,20 +31,29 @@ const init = async (): Promise<void> => {
   // <div data-view-component="true" class="unstarred BtnGroup ml-0 flex-1">
   // No matter the repo is starred or not, the two button are always there
   // So we need to filter the visible one
-  const $starButton = $(starButtonSelector).filter(function () {
-    if ($(this).parent().parent().css('display') !== 'none') {
-      return true;
-    } else {
-      return false;
-    }
+
+  // 选择所有的star按钮，不再进行过滤
+  const $starButtons = $(starButtonSelector);
+  // console.log($starButtons);
+  // const $starButton = $(starButtonSelector).filter(function () {
+  //   if ($(this).parent().parent().css('display') !== 'none') {
+  //     return true;
+  //   } else {
+  //     return false;
+  //   }
+  // });
+  // console.log($starButton);
+  // 为每个按钮渲染 NativePopover
+  $starButtons.each(function () {
+    console.log('Rendering popover for button:', $(this));
+    const placeholderElement = $('<div class="NativePopover" />').appendTo('body')[0];
+    render(
+      <NativePopover anchor={$(this)} width={280} arrowPosition="top-middle">
+        <View stars={stars} meta={meta} />
+      </NativePopover>,
+      placeholderElement
+    );
   });
-  const placeholderElement = $('<div class="NativePopover" />').appendTo('body')[0];
-  render(
-    <NativePopover anchor={$starButton} width={280} arrowPosition="top-middle">
-      <View stars={stars} meta={meta} />
-    </NativePopover>,
-    placeholderElement
-  );
 };
 
 const restore = async () => {};

--- a/src/pages/ContentScripts/features/repo-star-tooltip/index.tsx
+++ b/src/pages/ContentScripts/features/repo-star-tooltip/index.tsx
@@ -30,8 +30,6 @@ const init = async (): Promise<void> => {
   // <div data-view-component="true" class="starred BtnGroup flex-1 ml-0">
   // <div data-view-component="true" class="unstarred BtnGroup ml-0 flex-1">
   // No matter the repo is starred or not, the two button are always there
-  // So we need to filter the visible one
-
   // Select all star buttons and no more filtering
   const $starButtons = $(starButtonSelector);
   // Render NativePopover for each button

--- a/src/pages/ContentScripts/features/repo-star-tooltip/index.tsx
+++ b/src/pages/ContentScripts/features/repo-star-tooltip/index.tsx
@@ -32,20 +32,10 @@ const init = async (): Promise<void> => {
   // No matter the repo is starred or not, the two button are always there
   // So we need to filter the visible one
 
-  // 选择所有的star按钮，不再进行过滤
+  // Select all star buttons and no more filtering
   const $starButtons = $(starButtonSelector);
-  // console.log($starButtons);
-  // const $starButton = $(starButtonSelector).filter(function () {
-  //   if ($(this).parent().parent().css('display') !== 'none') {
-  //     return true;
-  //   } else {
-  //     return false;
-  //   }
-  // });
-  // console.log($starButton);
-  // 为每个按钮渲染 NativePopover
+  // Render NativePopover for each button
   $starButtons.each(function () {
-    console.log('Rendering popover for button:', $(this));
     const placeholderElement = $('<div class="NativePopover" />').appendTo('body')[0];
     render(
       <NativePopover anchor={$(this)} width={280} arrowPosition="top-middle">


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- resolved #874 

## Details
<img width="508" alt="image" src="https://github.com/user-attachments/assets/6d8cdbca-3259-4430-9b7a-c9cbf6c0f06e">

After clicking the star button, the page no longer displays the star image unless the page is refreshed.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
