### PR TITLE
fix: Modify deployment error message

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -30,13 +30,12 @@ const deployToChrome = async () => {
   const zipFile = fs.createReadStream(ZIP_PATH);
 
   const token = await chromeStore.fetchToken();
-
   const uploadRes = await chromeStore.uploadExisting(zipFile, token);
-  console.log({ uploadRes });
+  console.log('uploadRes: ', JSON.stringify(uploadRes, null, 2));
 
-  if (uploadRes.uploadState !== 'FAILURE') {
+  if (uploadRes.uploadState) {
     const publishRes = await chromeStore.publish('default', token);
-    console.log({ publishRes });
+    console.log('publishRes: ', { publishRes });
   }
 };
 
@@ -47,13 +46,16 @@ const deployToEdge = async () => {
     clientSecret: EDGE_CLIENT_SECRET,
     accessTokenUrl: EDGE_ACCESS_TOKEN_URL,
   });
-
-  const publishResp = await edgeStore.submit({
-    filePath: ZIP_PATH,
-    notes: 'Updating extension.',
-  });
-
-  console.log('publishResp: ', publishResp);
+  try {
+    const publishResp = await edgeStore.submit({
+      filePath: ZIP_PATH,
+      notes: 'Updating extension.',
+    });
+    console.log('Edge publishResp:', publishResp);
+  } catch (error) {
+    console.error('Edge Deployment failed:', error);
+    throw error;
+  }
 };
 
 (async () => {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -33,7 +33,7 @@ const deployToChrome = async () => {
   const uploadRes = await chromeStore.uploadExisting(zipFile, token);
   console.log('uploadRes: ', JSON.stringify(uploadRes, null, 2));
 
-  if (uploadRes.uploadState) {
+  if (uploadRes.uploadState !== 'FAILURE') {
     const publishRes = await chromeStore.publish('default', token);
     console.log('publishRes: ', { publishRes });
   }

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -31,11 +31,13 @@ const deployToChrome = async () => {
 
   const token = await chromeStore.fetchToken();
   const uploadRes = await chromeStore.uploadExisting(zipFile, token);
-  console.log('uploadRes: ', JSON.stringify(uploadRes, null, 2));
+  console.log('chrome uploadRes: ', JSON.stringify(uploadRes, null, 2));
 
   if (uploadRes.uploadState !== 'FAILURE') {
     const publishRes = await chromeStore.publish('default', token);
-    console.log('publishRes: ', { publishRes });
+    console.log('chrome publishRes: ', JSON.stringify(publishRes, null, 2));
+  } else {
+    process.exit(-1);
   }
 };
 
@@ -51,10 +53,10 @@ const deployToEdge = async () => {
       filePath: ZIP_PATH,
       notes: 'Updating extension.',
     });
-    console.log('Edge publishResp:', publishResp);
+    console.log('edge publishResp:', publishResp);
   } catch (error) {
-    console.error('Edge Deployment failed:', error);
-    throw error;
+    console.error('edge deployment failed:', error.message);
+    process.exit(-1);
   }
 };
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

https://github.com/hypertrons/hypertrons-crx/issues/884

## Details
<!-- What did you do in this PR?  -->
The return of uploadRes is an `item`, which can be changed to `JSON. stringify (uploadRes, null, 2)` to indicate the error message. The return information of Edge's `publishResp` is a string. To capture its erroneous information, it became a `try... catch...`.
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
