### PR TITLE
fix: fix GitHub token storage and obtain

### DIFF
--- a/src/api/githubApi.ts
+++ b/src/api/githubApi.ts
@@ -1,7 +1,7 @@
 import { getToken, saveToken } from '../helpers/github-token';
 
 export const githubRequest = async (endpoint: string, options: RequestInit = {}): Promise<any | null> => {
-  const token = getToken();
+  const token = await getToken();
   if (!token) {
     return null;
   }

--- a/src/helpers/github-token.ts
+++ b/src/helpers/github-token.ts
@@ -1,7 +1,11 @@
 export const saveToken = (token: string) => {
-  localStorage.setItem('github_token', token);
+  chrome.storage.sync.set({ github_token: token });
 };
 
-export const getToken = (): string => {
-  return localStorage.getItem('github_token') || '';
+export const getToken = (): Promise<string | null> => {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get('github_token', (result) => {
+      resolve(result.github_token || null);
+    });
+  });
 };

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -129,6 +129,17 @@ const Options = (): JSX.Element => {
               display: 'flex',
               justifyContent: 'center',
               alignItems: 'center',
+              margin: stacksStyleOptions.tokenStack.margin,
+            }}
+          >
+            <GitHubToken /> {/* Add GitHubToken component */}
+          </Col>
+          <Col
+            span={24}
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
             }}
           >
             <div className="Box">
@@ -146,17 +157,6 @@ const Options = (): JSX.Element => {
                 </p>
               </div>
             </div>
-          </Col>
-          <Col
-            span={24}
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              margin: stacksStyleOptions.tokenStack.margin,
-            }}
-          >
-            <GitHubToken /> {/* Add GitHubToken component */}
           </Col>
         </Row>
       </Space>

--- a/src/pages/Options/components/GitHubToken.tsx
+++ b/src/pages/Options/components/GitHubToken.tsx
@@ -10,12 +10,14 @@ const GitHubToken = () => {
   const [isEditing, setIsEditing] = useState(false);
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const storedToken = getToken();
+  const fetchToken = async () => {
+    const storedToken = await getToken();
     if (storedToken) {
       setToken(storedToken);
     }
+  };
+  useEffect(() => {
+    fetchToken();
   }, []);
 
   const handleSave = () => {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- keyword: https://github.com/hypertrons/hypertrons-crx/issues/773#issuecomment-2440828932

## Details
<!-- What did you do in this PR?  -->
I encountered an issue while developing other features that require the use of GitHub tokens. The feature of storing and using GitHub tokens on the option page previously done by others is not available, and you will find that you cannot obtain GitHub tokens already stored on other pages at all. I have already made the necessary changes to this section.
`localStorage.setItem`：If you use localStorage in the options page of the plugin, the stored data can only be used in that option page and the same plugin context.
Use the `chrome. storage` API to storage and obtain data. This API can share data in all contexts, including option pages and content scripts.
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
