### PR TITLE
fix: Added a way to retrieve repository names through the page

### DIFF
--- a/src/helpers/get-developer-info.ts
+++ b/src/helpers/get-developer-info.ts
@@ -4,7 +4,19 @@ import $ from 'jquery';
 import * as pageDetect from 'github-url-detection';
 
 export function getDeveloperName() {
+  const developerNameByUrl = getDeveloperNameByUrl();
+  const developerNameByPage = getDeveloperNameByPage();
+  if (developerNameByUrl.toLowerCase() === developerNameByPage.toLowerCase()) {
+    return developerNameByPage;
+  }
+  return developerNameByUrl;
+}
+
+export function getDeveloperNameByPage() {
   return $('.p-nickname.vcard-username.d-block').text().trim().split(' ')[0];
+}
+export function getDeveloperNameByUrl() {
+  return pageDetect.utils.getUsername()!;
 }
 
 export async function isDeveloperWithMeta() {

--- a/src/helpers/get-repo-info.ts
+++ b/src/helpers/get-repo-info.ts
@@ -5,6 +5,24 @@ import * as pageDetect from 'github-url-detection';
 import elementReady from 'element-ready';
 
 export function getRepoName() {
+  const repoNameByUrl = getRepoNameByUrl();
+  const repoNameByPage = getRepoNameByPage();
+  if (repoNameByUrl.toLowerCase() === repoNameByPage.toLowerCase()) {
+    return repoNameByPage;
+  }
+  return repoNameByUrl;
+}
+
+export function getRepoNameByPage() {
+  let repoName: string[] = [];
+  $('header span.AppHeader-context-item-label').map(function () {
+    repoName.push($(this).text().trim());
+  });
+  let repoFullName = repoName[0] + '/' + repoName[1];
+  return repoFullName;
+}
+
+export function getRepoNameByUrl() {
   return pageDetect.utils.getRepositoryInfo(window.location)!.nameWithOwner;
 }
 
@@ -29,5 +47,5 @@ export async function isPublicRepo() {
 }
 
 export async function isPublicRepoWithMeta() {
-  return (await isPublicRepo()) && (await metaStore.has(getRepoName()));
+  return (await isPublicRepo()) && ((await metaStore.has(getRepoName())) || (await metaStore.has(getRepoNameByPage())));
 }


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- related to #773 

## Details
<!-- What did you do in this PR?  -->
Added a method to retrieve the repository name via page elements, while also retaining the option to retrieve it from the URL. This ensures that even if the names obtained by both methods differ in case, the result parsed from page elements takes priority. This approach also allows for fallback to URL-based retrieval in case of GitHub page structure changes.

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/c8aa9fc4-27c5-4e74-a70c-8f8e0394bb29">


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
