### PR TITLE
fix: Delete unnecessary permissions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,7 @@
       "matches": ["<all_urls>"]
     }
   ],
-  "permissions": ["storage", "notifications", "alarms", "cookies"],
+  "permissions": ["storage"],
   "host_permissions": ["<all_urls>"],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self';"


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


## Details
<!-- What did you do in this PR?  -->

Delete permissions that are not used but requested from chrome.
* notifications
* alarms
* cookies

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/611a8133-7c79-4177-a026-f9b14655427f">


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
