### PR TITLE
feat: improve fast pr in selecting text

### DIFF
--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -1,0 +1,5 @@
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.url) {
+    chrome.tabs.sendMessage(tabId, { type: 'urlChanged', url: changeInfo.url });
+  }
+});

--- a/src/pages/ContentScripts/features/fast-pr/index.tsx
+++ b/src/pages/ContentScripts/features/fast-pr/index.tsx
@@ -55,30 +55,21 @@ const init = async (matchedUrl: MatchedUrl | null) => {
     document.body.appendChild(container);
   }
 };
-const observeUrlChanges = () => {
-  let lastUrl = window.location.href;
-  const checkUrlChange = () => {
-    const currentUrl = window.location.href;
-    if (currentUrl !== lastUrl) {
-      lastUrl = currentUrl;
-      const existingContainer = document.getElementById(featureId);
-      if (existingContainer) {
-        existingContainer.remove();
-      }
-      const iframe = document.getElementById('sandboxFrame') as HTMLIFrameElement;
-      if (iframe && iframe.contentWindow) {
-        iframe.contentWindow.postMessage({ command: 'matchUrl', url: currentUrl }, '*');
-      }
-    }
-  };
-  const observer = new MutationObserver(checkUrlChange);
-  observer.observe(document.body, {
-    childList: true,
-    subtree: true,
-  });
-  setInterval(checkUrlChange, 1000);
-};
-
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'urlChanged') {
+    handleUrlChange(message.url);
+  }
+});
+function handleUrlChange(url: string) {
+  const existingContainer = document.getElementById(featureId);
+  if (existingContainer) {
+    existingContainer.remove();
+  }
+  const iframe = document.getElementById('sandboxFrame') as HTMLIFrameElement;
+  if (iframe && iframe.contentWindow) {
+    iframe.contentWindow.postMessage({ command: 'matchUrl', url: url }, '*');
+  }
+}
 window.addEventListener('message', (event: MessageEvent) => {
   if (event.data && event.data.matchedUrl) {
     init(event.data.matchedUrl);
@@ -102,6 +93,5 @@ features.add(featureId, {
         }
       }, 500);
     };
-    observeUrlChanges();
   },
 });

--- a/src/pages/ContentScripts/features/fast-pr/view.tsx
+++ b/src/pages/ContentScripts/features/fast-pr/view.tsx
@@ -197,7 +197,6 @@ const View = ({ filePath, originalRepo, branch, platform, horizontalRatio, verti
     if (platform === 'Github') githubService.submitGithubPR(form, originalRepo, branch, filePath, fileContent);
     else giteeService.submitGiteePR(form, originalRepo, branch, filePath, fileContent);
   };
-  //Check if there is selected text
   const moveButtonToMouseUpPosition = (event: MouseEvent) => {
     const selection = window.getSelection();
     if (selection && selection.rangeCount > 0 && selection.toString().trim() !== '') {
@@ -209,7 +208,7 @@ const View = ({ filePath, originalRepo, branch, platform, horizontalRatio, verti
       });
     }
   };
-
+  //Check if there is selected text
   const checkTextSelection = () => {
     const selection = window.getSelection();
     return selection && selection.rangeCount > 0 && selection.toString().trim() !== '';

--- a/src/pages/ContentScripts/features/fast-pr/view.tsx
+++ b/src/pages/ContentScripts/features/fast-pr/view.tsx
@@ -33,6 +33,7 @@ const View = ({ filePath, originalRepo, branch, platform, horizontalRatio, verti
   const [fileContent, setFileContent] = useState('');
   const buttonSize = 50; // Button size
   const padding = 24; // Padding from the screen edges
+  let textSelected = false;
   const dragThreshold = 5; // Threshold to distinguish dragging from clicking
   const GITHUB_FILE_URL = (filePath: string, originalRepo: string, branch: string) =>
     `https://raw.githubusercontent.com/${originalRepo}/${branch}/${filePath}`;
@@ -209,25 +210,38 @@ const View = ({ filePath, originalRepo, branch, platform, horizontalRatio, verti
     }
   };
 
+  const checkTextSelection = () => {
+    const selection = window.getSelection();
+    return selection && selection.rangeCount > 0 && selection.toString().trim() !== '';
+  };
+
+  //Check if the text is selected when the mouse is raised
   useEffect(() => {
     const handleGlobalMouseUp = (event: MouseEvent) => {
-      //Check if there is selected text
-      moveButtonToMouseUpPosition(event);
+      if (checkTextSelection()) {
+        textSelected = true;
+        moveButtonToMouseUpPosition(event);
+      } else {
+        textSelected = false;
+      }
     };
     document.addEventListener('mouseup', handleGlobalMouseUp);
     return () => {
       document.removeEventListener('mouseup', handleGlobalMouseUp);
     };
   }, []);
+
+  //Return to the initial position when scrolling, only after selecting text
   useEffect(() => {
     const handleScroll = () => {
-      const initialX = (window.innerWidth - buttonSize) * horizontalRatio;
-      const initialY = (window.innerHeight - buttonSize) * verticalRatio;
-      setPosition({ x: initialX, y: initialY });
+      if (textSelected) {
+        const initialX = (window.innerWidth - buttonSize) * horizontalRatio;
+        const initialY = (window.innerHeight - buttonSize) * verticalRatio;
+        setPosition({ x: initialX, y: initialY });
+        textSelected = false;
+      }
     };
-
     document.addEventListener('scroll', handleScroll);
-
     return () => {
       document.removeEventListener('scroll', handleScroll);
     };

--- a/src/pages/ContentScripts/features/fast-pr/view.tsx
+++ b/src/pages/ContentScripts/features/fast-pr/view.tsx
@@ -196,6 +196,42 @@ const View = ({ filePath, originalRepo, branch, platform, horizontalRatio, verti
     if (platform === 'Github') githubService.submitGithubPR(form, originalRepo, branch, filePath, fileContent);
     else giteeService.submitGiteePR(form, originalRepo, branch, filePath, fileContent);
   };
+  //Check if there is selected text
+  const moveButtonToMouseUpPosition = (event: MouseEvent) => {
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount > 0 && selection.toString().trim() !== '') {
+      const newX = event.clientX; //Horizontal position of mouse lift
+      const newY = event.clientY; //Vertical position of mouse lift
+      setPosition({
+        x: Math.min(newX, window.innerWidth - buttonSize - padding),
+        y: Math.min(newY, window.innerHeight - buttonSize - padding),
+      });
+    }
+  };
+
+  useEffect(() => {
+    const handleGlobalMouseUp = (event: MouseEvent) => {
+      //Check if there is selected text
+      moveButtonToMouseUpPosition(event);
+    };
+    document.addEventListener('mouseup', handleGlobalMouseUp);
+    return () => {
+      document.removeEventListener('mouseup', handleGlobalMouseUp);
+    };
+  }, []);
+  useEffect(() => {
+    const handleScroll = () => {
+      const initialX = (window.innerWidth - buttonSize) * horizontalRatio;
+      const initialY = (window.innerHeight - buttonSize) * verticalRatio;
+      setPosition({ x: initialX, y: initialY });
+    };
+
+    document.addEventListener('scroll', handleScroll);
+
+    return () => {
+      document.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
   // When the mouse is released, stop dragging, and determine if it's a click or drag
   const handleMouseUp = () => {
     if (!dragged) {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- keyword #905

## Details
<!-- What did you do in this PR?  -->

https://github.com/user-attachments/assets/4f172172-bd80-475f-9845-188ae9f7d016


When the user selects text, the button will move to the last position of the mouse. When the mouse scrolls, the button will return to its original position.Scroll back to its original position only after selecting text, and remain in the dragged position after dragging.
Except https://www.kaiwudb.com/kaiwudb_docs. Because the construction of their document website is an iframe, it cannot obtain mouse operations.
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/0b7e3c32-06e1-4059-ad0e-f89def8c2363">

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
