### PR TITLE
fix: fix the method of obtaining developer names

### DIFF
--- a/src/helpers/get-developer-info.ts
+++ b/src/helpers/get-developer-info.ts
@@ -16,7 +16,11 @@ export function getDeveloperNameByPage() {
   return $('.p-nickname.vcard-username.d-block').text().trim().split(' ')[0];
 }
 export function getDeveloperNameByUrl() {
-  return pageDetect.utils.getUsername()!;
+  const currentUrl = window.location.href;
+  const parsedUrl = new URL(currentUrl);
+  const pathParts = parsedUrl.pathname.split('/');
+  const developerName = pathParts[pathParts.length - 1];
+  return developerName;
 }
 
 export async function isDeveloperWithMeta() {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):



## Details
<!-- What did you do in this PR?  -->
<img width="1121" alt="image" src="https://github.com/user-attachments/assets/1df82fbc-e272-4d93-ba12-a51615ad8f43">
The method for obtaining the developer's name is incorrect, resulting in the name of the logged in user being consistently obtained instead of the developer's name. Related repairs have been made.

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/80d4df31-d6db-48ff-ac30-6dc3499af03d">

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
