### PR TITLE
fix: OSS-GPT is enabled for all pages

### DIFF
--- a/src/helpers/get-github-repo-info.ts
+++ b/src/helpers/get-github-repo-info.ts
@@ -44,17 +44,11 @@ export async function isRepoRoot() {
  * check if the repository is public
  */
 export async function isPublicRepo() {
-  const platform = getPlatform();
-  if (platform === 'github') {
-    const selector = 'meta[name="octolytics-dimension-repository_public"]';
-    await elementReady(selector);
-    // <meta name="octolytics-dimension-repository_public" content="true/false">
-    const isPublic = $(selector).attr('content') === 'true';
-    return pageDetect.isRepo() && isPublic;
-  } else {
-    // TODO
-    return true;
-  }
+  const selector = 'meta[name="octolytics-dimension-repository_public"]';
+  await elementReady(selector);
+  // <meta name="octolytics-dimension-repository_public" content="true/false">
+  const isPublic = $(selector).attr('content') === 'true';
+  return pageDetect.isRepo() && isPublic;
 }
 export async function isPublicRepoWithMeta() {
   const platform = getPlatform();


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- keyword #978

## Details
<!-- What did you do in this PR?  -->
Right now, it seems that OSS GPT feature is enabled for all pages, like in Google search page and stack overflow page, it is definitely not necessary at all. We should at least constrain the feature within GitHub and Gitee right now.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
