### PR TITLE
fix: Perceptor tab always shows for Gitee repo

### DIFF
--- a/src/pages/ContentScripts/features/perceptor-tab/gitee-index.tsx
+++ b/src/pages/ContentScripts/features/perceptor-tab/gitee-index.tsx
@@ -2,7 +2,7 @@ import elementReady from 'element-ready';
 import iconSvgPath from './icon-svg-path';
 import features from '../../../../feature-manager';
 import isPerceptor from '../../../../helpers/is-perceptor';
-import { isPublicRepo } from '../../../../helpers/get-gitee-repo-info';
+import { isPublicRepoWithMeta } from '../../../../helpers/get-gitee-repo-info';
 import isGitee from '../../../../helpers/is-gitee';
 
 const featureId = features.getFeatureID(import.meta.url);
@@ -70,7 +70,7 @@ const init = async (): Promise<void> => {
 };
 
 features.add(featureId, {
-  asLongAs: [isGitee, isPublicRepo],
+  asLongAs: [isGitee, isPublicRepoWithMeta],
   awaitDomReady: false,
   init,
 });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- keyword #981 

## Details
<!-- What did you do in this PR?  -->
Modified the conditions for the appearance of the perceptor-tab. In Gitee, the repository must have metadata (meta.json) before it is displayed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx)

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
